### PR TITLE
SCRUM-235 fix: fix fab overlap with bottombar

### DIFF
--- a/app/src/main/java/com/lyrics/feelin/navigation/FeelinNavHost.kt
+++ b/app/src/main/java/com/lyrics/feelin/navigation/FeelinNavHost.kt
@@ -1,5 +1,6 @@
 package com.lyrics.feelin.navigation
 
+import android.util.Log
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.calculateEndPadding
@@ -15,6 +16,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -83,6 +85,18 @@ fun FeelinNavHost(
         },
         contentWindowInsets = WindowInsets(0)
     ) { paddingValues ->
+        var bottomPadding = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
+        // resources.getIdentifier()를 이용해 내비게이션 바의 크기를 받는 방법도 시도해 보았지만,
+        // 일부 경우에서는 크기를 제대로 가져오지 못합니다.
+        // 이에 아래의 측정치를 따라, 받아온 bottomPadding의 dp가 30 이하일 경우 WindowInsets이 아닌
+        // Scaffold에서 받은 bottomPadding을 하위 컴포저블에서 가지도록 수정합니다. @이대근
+        // 픽셀9 에뮬레이터 24dp, S23울트라 실기기 14.857142.dp, 노트10플러스 실기기 15.142858.dp
+        if (bottomPadding <= 30.dp) {
+            bottomPadding = paddingValues.calculateBottomPadding()
+        }
+        Log.d("MainActivity", "FeelinNavHost: bottomPadding $bottomPadding")
+        Log.d("MainActivity", "FeelinNavHost: paddingValues $paddingValues")
+
         NavHost(
             navController = navController,
             startDestination = startDestination,
@@ -92,7 +106,7 @@ fun FeelinNavHost(
                     top = paddingValues.calculateTopPadding(),
                     start = paddingValues.calculateEndPadding(LayoutDirection.Ltr),
                     end = paddingValues.calculateEndPadding(LayoutDirection.Ltr),
-                    bottom = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
+                    bottom = bottomPadding
                 )
         ) {
             composable(FeelinDestination.Home.route) {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] The commit message follows our guidelines
<!-- - [ ] Tests for the changes have been added (for bug fixes / features) ~~  -->
<!-- - [ ] Docs have been added / updated (for bug fixes / features) -->


## What kind of change does this PR introduce?
> Select your one and delete others
- Bug fix


# What is the current behavior?
>  You can also link to an open issue here

[SCRUM-235](https://projectlyrics.atlassian.net/browse/SCRUM-235?atlOrigin=eyJpIjoiYTYzNzBmZDA4YWY4NGVkNWEzNGY5NmM3NDlkNTdlNWMiLCJwIjoiaiJ9)
시스템 설정이 동적 탐색일 경우 NavHost 상위 Scaffold의 BottomBar와 하위 Scaffold의 FAB이 겹치는 상황입니다.

# What is the new behavior (if this is a feature change)?
- NavHost가 위치하는 컴포저블의 설정을 통해 하위 컴포저블이 배치될 크기를 잡습니다.
  - 시스템 설정이 동적 탐색일 경우 Scaffold에서 받는 BottomPadding을 전달합니다.
  - 시스템 설정이 3버튼(+2버튼) 탐색일 경우 기존과 동일하게 WindowInsets에서 받는 BottomPadding을 전달합니다.
- 시스템 설정을 구분하는 기준은 WindowInsets를 통해 받는 BottomPadding값에 동적 탐색에 대한 Threshold를 정한 것입니다.
  - 의외로 해당 설정을 가져오는 값이 없어, 크기를 임의로 기준해 잡았습니다.


## Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No


## ScreenShots (If needed)
### 3버튼 탐색
순서대로 Note10플러스 안드로이드 11, 픽셀6 에뮬레이터 안드로이드 11입니다.
<p>
  <img src="https://github.com/user-attachments/assets/effff473-2558-4f47-9e97-f5998521b55d", width="300" />
</p>
<p>
  <img src="https://github.com/user-attachments/assets/f2f4d786-caf4-41f6-bfa6-76c12d1c2f78", width="300" />
</p>

### 네비게이션 바
순서대로 Note10플러스 안드로이드 11, 픽셀6 에뮬레이터 안드로이드 11입니다.
다만 FAB 높이가 조금 높게 잡히는 듯 하네요?
<p>
  <img src="https://github.com/user-attachments/assets/f6306718-b521-4599-a129-52be3484167f", width="300" />
</p>
<p>
  <img src="https://github.com/user-attachments/assets/b3fb65b3-ade1-4ba7-a464-c5e12cf8bd37", width="300" />
</p>

### 네비게이션 바 + GoodLock NavStar를 이용한 내비게이션 바 힌트 영역 삭제
<p>
  <img src="https://github.com/user-attachments/assets/cc44571b-f7c3-4b59-bb3e-23520568751b", width="300" />
</p>


[SCRUM-235]: https://projectlyrics.atlassian.net/browse/SCRUM-235?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ