### PR TITLE
SCRUM-247 feature: add login identifier header

### DIFF
--- a/app/src/main/java/com/lyrics/feelin/core/data/datasource/local/DeviceIdDataStore.kt
+++ b/app/src/main/java/com/lyrics/feelin/core/data/datasource/local/DeviceIdDataStore.kt
@@ -10,6 +10,7 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import java.util.UUID
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlinx.coroutines.flow.first
 
 private val Context.deviceIdDataStore: DataStore<Preferences> by preferencesDataStore(name = "device_id")
 
@@ -18,16 +19,20 @@ class DeviceIdDataStore @Inject constructor(
     @param:ApplicationContext private val context: Context
 ) {
     suspend fun getOrCreate(): String {
-        var deviceId: String? = null
-
-        context.deviceIdDataStore.edit { preferences ->
-            deviceId = preferences[DEVICE_ID_KEY]
-                ?: UUID.randomUUID().toString().also { generatedDeviceId ->
-                    preferences[DEVICE_ID_KEY] = generatedDeviceId
-                }
+        val existingDeviceId = context.deviceIdDataStore.data.first()[DEVICE_ID_KEY]
+        if (existingDeviceId != null) {
+            return existingDeviceId
         }
 
-        return checkNotNull(deviceId)
+        val generatedDeviceId = UUID.randomUUID().toString()
+        var storedDeviceId = generatedDeviceId
+
+        context.deviceIdDataStore.edit { preferences ->
+            storedDeviceId = preferences[DEVICE_ID_KEY]
+                ?: generatedDeviceId.also { preferences[DEVICE_ID_KEY] = it }
+        }
+
+        return storedDeviceId
     }
 
     companion object {

--- a/app/src/main/java/com/lyrics/feelin/core/data/datasource/local/DeviceIdDataStore.kt
+++ b/app/src/main/java/com/lyrics/feelin/core/data/datasource/local/DeviceIdDataStore.kt
@@ -1,0 +1,36 @@
+package com.lyrics.feelin.core.data.datasource.local
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import dagger.hilt.android.qualifiers.ApplicationContext
+import java.util.UUID
+import javax.inject.Inject
+import javax.inject.Singleton
+
+private val Context.deviceIdDataStore: DataStore<Preferences> by preferencesDataStore(name = "device_id")
+
+@Singleton
+class DeviceIdDataStore @Inject constructor(
+    @param:ApplicationContext private val context: Context
+) {
+    suspend fun getOrCreate(): String {
+        var deviceId: String? = null
+
+        context.deviceIdDataStore.edit { preferences ->
+            deviceId = preferences[DEVICE_ID_KEY]
+                ?: UUID.randomUUID().toString().also { generatedDeviceId ->
+                    preferences[DEVICE_ID_KEY] = generatedDeviceId
+                }
+        }
+
+        return checkNotNull(deviceId)
+    }
+
+    companion object {
+        private val DEVICE_ID_KEY = stringPreferencesKey("device_id")
+    }
+}

--- a/app/src/main/java/com/lyrics/feelin/core/data/datasource/remote/AuthApiService.kt
+++ b/app/src/main/java/com/lyrics/feelin/core/data/datasource/remote/AuthApiService.kt
@@ -3,27 +3,30 @@ package com.lyrics.feelin.core.data.datasource.remote
 import com.lyrics.feelin.core.data.datasource.remote.dto.RefreshTokenRequestDto
 import com.lyrics.feelin.core.data.datasource.remote.dto.ServerStatusResponseDto
 import com.lyrics.feelin.core.data.datasource.remote.dto.SignInRequestDto
+import com.lyrics.feelin.core.data.interceptor.DEVICE_ID_MARKER_HEADER
 import com.lyrics.feelin.core.domain.model.AuthToken
 import com.lyrics.feelin.core.domain.model.SignUpData
 import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.DELETE
 import retrofit2.http.GET
-import retrofit2.http.Header
+import retrofit2.http.Headers
 import retrofit2.http.POST
 
 interface AuthApiService {
     @DELETE("api/v1/auth/delete")
     suspend fun deleteAccount(): Response<ServerStatusResponseDto>
 
+    @Headers("$DEVICE_ID_MARKER_HEADER: true")
     @POST("api/v1/auth/sign-in")
-    suspend fun signIn(@Header("Device-Id") deviceId: String, @Body body: SignInRequestDto): Response<AuthToken>
+    suspend fun signIn(@Body body: SignInRequestDto): Response<AuthToken>
 
     @DELETE("api/v1/auth/sign-out")
     suspend fun signOut(): Response<ServerStatusResponseDto>
 
+    @Headers("$DEVICE_ID_MARKER_HEADER: true")
     @POST("api/v1/auth/sign-up")
-    suspend fun signUp(@Header("Device-Id") deviceId: String, @Body body: SignUpData): Response<AuthToken>
+    suspend fun signUp(@Body body: SignUpData): Response<AuthToken>
 
     @POST("api/v1/auth/token")
     suspend fun reIssueToken(@Body refreshTokenDto: RefreshTokenRequestDto): Response<AuthToken>

--- a/app/src/main/java/com/lyrics/feelin/core/data/datasource/remote/AuthRemoteDataSource.kt
+++ b/app/src/main/java/com/lyrics/feelin/core/data/datasource/remote/AuthRemoteDataSource.kt
@@ -14,10 +14,9 @@ import javax.inject.Singleton
 class AuthRemoteDataSource @Inject constructor(
     private val authApiService: AuthApiService
 ) {
-    suspend fun signIn(provider: OAuthProvider, oAuthToken: OAuthToken, deviceId: String): Result<AuthToken> {
+    suspend fun signIn(provider: OAuthProvider, oAuthToken: OAuthToken): Result<AuthToken> {
         return safeApiCall {
             authApiService.signIn(
-                deviceId = deviceId,
                 body = SignInRequestDto(
                     socialAccessToken = oAuthToken.accessToken,
                     authProvider = provider
@@ -31,8 +30,8 @@ class AuthRemoteDataSource @Inject constructor(
     }
 
     // TODO(@이대근): 온보딩 화면 제작하면서 연동 필요 2025.10.12.
-    suspend fun signUp(deviceId: String, signUpData: SignUpData): Result<AuthToken> {
-        return safeApiCall { authApiService.signUp(deviceId = deviceId, body = signUpData) }
+    suspend fun signUp(signUpData: SignUpData): Result<AuthToken> {
+        return safeApiCall { authApiService.signUp(body = signUpData) }
     }
 
     suspend fun deleteAccount(): Result<ServerStatusResponseDto> {

--- a/app/src/main/java/com/lyrics/feelin/core/data/di/NetworkModule.kt
+++ b/app/src/main/java/com/lyrics/feelin/core/data/di/NetworkModule.kt
@@ -41,6 +41,7 @@ object NetworkModule {
                 redactHeader("Cookie")
                 redactHeader("Proxy-Authorization")
                 redactHeader("Set-Cookie")
+                redactHeader("Device-Id")
             }
 
         return OkHttpClient.Builder()

--- a/app/src/main/java/com/lyrics/feelin/core/data/di/NetworkModule.kt
+++ b/app/src/main/java/com/lyrics/feelin/core/data/di/NetworkModule.kt
@@ -5,6 +5,7 @@ import com.lyrics.feelin.BuildConfig
 import com.lyrics.feelin.core.data.datasource.remote.AuthApiService
 import com.lyrics.feelin.core.data.interceptor.AppVersionInterceptor
 import com.lyrics.feelin.core.data.interceptor.AuthInterceptor
+import com.lyrics.feelin.core.data.interceptor.DeviceIdInterceptor
 import com.lyrics.feelin.core.data.interceptor.TokenAuthenticator
 import dagger.Module
 import dagger.Provides
@@ -25,6 +26,7 @@ object NetworkModule {
     @Singleton
     fun provideOkHttpClient(
         appVersionInterceptor: AppVersionInterceptor,
+        deviceIdInterceptor: DeviceIdInterceptor,
         authInterceptor: AuthInterceptor,
         tokenAuthenticator: TokenAuthenticator
     ): OkHttpClient {
@@ -43,6 +45,7 @@ object NetworkModule {
 
         return OkHttpClient.Builder()
             .addInterceptor(appVersionInterceptor)
+            .addInterceptor(deviceIdInterceptor)
             .addInterceptor(authInterceptor)
             .addInterceptor(httpLoggingInterceptor)
             .authenticator(tokenAuthenticator)

--- a/app/src/main/java/com/lyrics/feelin/core/data/interceptor/DeviceIdInterceptor.kt
+++ b/app/src/main/java/com/lyrics/feelin/core/data/interceptor/DeviceIdInterceptor.kt
@@ -1,0 +1,35 @@
+package com.lyrics.feelin.core.data.interceptor
+
+import com.lyrics.feelin.core.data.datasource.local.DeviceIdDataStore
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.runBlocking
+import okhttp3.Interceptor
+import okhttp3.Response
+
+const val DEVICE_ID_MARKER_HEADER = "X-Requires-Device-Id"
+
+@Singleton
+class DeviceIdInterceptor @Inject constructor(
+    private val deviceIdDataStore: DeviceIdDataStore
+) : Interceptor {
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val originalRequest = chain.request()
+
+        if (originalRequest.header(DEVICE_ID_MARKER_HEADER) == null) {
+            return chain.proceed(originalRequest)
+        }
+
+        val deviceId = runBlocking {
+            deviceIdDataStore.getOrCreate()
+        }
+
+        val requestWithDeviceId = originalRequest.newBuilder()
+            .removeHeader(DEVICE_ID_MARKER_HEADER)
+            .header("Device-Id", deviceId)
+            .build()
+
+        return chain.proceed(requestWithDeviceId)
+    }
+}

--- a/app/src/main/java/com/lyrics/feelin/core/data/repository/AuthRepository.kt
+++ b/app/src/main/java/com/lyrics/feelin/core/data/repository/AuthRepository.kt
@@ -1,6 +1,5 @@
 package com.lyrics.feelin.core.data.repository
 
-import com.lyrics.feelin.core.data.datasource.local.DeviceIdDataStore
 import com.lyrics.feelin.core.data.datasource.remote.AuthRemoteDataSource
 import com.lyrics.feelin.core.data.datasource.remote.dto.exception.FeelinServerException
 import com.lyrics.feelin.core.data.datasource.sdk.GoogleAuthDataSource
@@ -34,7 +33,6 @@ class AuthRepository @Inject constructor(
     private val kakaoAuthDataSource: KakaoAuthDataSource,
     @Suppress("UnusedPrivateMember") // TODO(@이대근): 구글 로그인 구현 중 어노테이션 제거할 것. 2025.10.02.
     private val googleAuthDataSource: GoogleAuthDataSource,
-    private val deviceIdDataStore: DeviceIdDataStore,
     private val authRemoteDataSource: AuthRemoteDataSource,
     private val authManager: AuthManager
 ) {
@@ -55,12 +53,9 @@ class AuthRepository @Inject constructor(
         provider: OAuthProvider,
         oauthToken: OAuthToken
     ): Result<Unit> {
-        val deviceId = deviceIdDataStore.getOrCreate()
-
         val result = authRemoteDataSource.signIn(
             provider = provider,
-            oAuthToken = oauthToken,
-            deviceId = deviceId
+            oAuthToken = oauthToken
         )
 
         val failure = result.exceptionOrNull()?.let { error ->
@@ -184,10 +179,8 @@ class AuthRepository @Inject constructor(
     // ========== 회원가입 ==========
 
     suspend fun signUp(signUpData: SignUpData): Result<Unit> {
-        val deviceId = deviceIdDataStore.getOrCreate()
-
         val tokenResult =
-            authRemoteDataSource.signUp(deviceId = deviceId, signUpData = signUpData).onFailure {
+            authRemoteDataSource.signUp(signUpData = signUpData).onFailure {
                 return Result.failure(exception = it)
             }
 

--- a/app/src/main/java/com/lyrics/feelin/core/data/repository/AuthRepository.kt
+++ b/app/src/main/java/com/lyrics/feelin/core/data/repository/AuthRepository.kt
@@ -1,5 +1,6 @@
 package com.lyrics.feelin.core.data.repository
 
+import com.lyrics.feelin.core.data.datasource.local.DeviceIdDataStore
 import com.lyrics.feelin.core.data.datasource.remote.AuthRemoteDataSource
 import com.lyrics.feelin.core.data.datasource.remote.dto.exception.FeelinServerException
 import com.lyrics.feelin.core.data.datasource.sdk.GoogleAuthDataSource
@@ -33,6 +34,7 @@ class AuthRepository @Inject constructor(
     private val kakaoAuthDataSource: KakaoAuthDataSource,
     @Suppress("UnusedPrivateMember") // TODO(@이대근): 구글 로그인 구현 중 어노테이션 제거할 것. 2025.10.02.
     private val googleAuthDataSource: GoogleAuthDataSource,
+    private val deviceIdDataStore: DeviceIdDataStore,
     private val authRemoteDataSource: AuthRemoteDataSource,
     private val authManager: AuthManager
 ) {
@@ -53,10 +55,12 @@ class AuthRepository @Inject constructor(
         provider: OAuthProvider,
         oauthToken: OAuthToken
     ): Result<Unit> {
+        val deviceId = deviceIdDataStore.getOrCreate()
+
         val result = authRemoteDataSource.signIn(
             provider = provider,
             oAuthToken = oauthToken,
-            deviceId = "android-develop-test-202603200009"
+            deviceId = deviceId
         )
 
         val failure = result.exceptionOrNull()?.let { error ->
@@ -179,7 +183,9 @@ class AuthRepository @Inject constructor(
 
     // ========== 회원가입 ==========
 
-    suspend fun signUp(deviceId: String, signUpData: SignUpData): Result<Unit> {
+    suspend fun signUp(signUpData: SignUpData): Result<Unit> {
+        val deviceId = deviceIdDataStore.getOrCreate()
+
         val tokenResult =
             authRemoteDataSource.signUp(deviceId = deviceId, signUpData = signUpData).onFailure {
                 return Result.failure(exception = it)

--- a/app/src/main/res/xml/backup_rules.xml
+++ b/app/src/main/res/xml/backup_rules.xml
@@ -6,8 +6,5 @@
    See https://developer.android.com/about/versions/12/backup-restore
 -->
 <full-backup-content>
-    <!--
-   <include domain="sharedpref" path="."/>
-   <exclude domain="sharedpref" path="device.xml"/>
--->
+    <exclude domain="file" path="datastore/device_id.preferences_pb"/>
 </full-backup-content>

--- a/app/src/main/res/xml/data_extraction_rules.xml
+++ b/app/src/main/res/xml/data_extraction_rules.xml
@@ -5,15 +5,9 @@
 -->
 <data-extraction-rules>
     <cloud-backup>
-        <!-- TODO: Use <include> and <exclude> to control what is backed up.
-        <include .../>
-        <exclude .../>
-        -->
+        <exclude domain="file" path="datastore/device_id.preferences_pb"/>
     </cloud-backup>
-    <!--
     <device-transfer>
-        <include .../>
-        <exclude .../>
+        <exclude domain="file" path="datastore/device_id.preferences_pb"/>
     </device-transfer>
-    -->
 </data-extraction-rules>


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] The commit message follows our guidelines
<!-- - [ ] Tests for the changes have been added (for bug fixes / features) ~~  -->
<!-- - [ ] Docs have been added / updated (for bug fixes / features) -->


## What kind of change does this PR introduce?

- Add feature


# What is the current behavior?

로그인시 임의의 디바이스 식별자 값을 삽입합니다.


# What is the new behavior (if this is a feature change)?

기기별로 GUID를 생성해 로그인 시에 삽입합니다.



## Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No Breaking Chages.
커스텀 헤더를 추가하지만 헤더가 붙지 않은 기존 API에는 호출에 영향을 받지 않습니다.



## Reproductive QA steps

0. 앱을 디버그로 실행합니다.
1. App Inspection -> Android Studio Network Inspector를 실행합니다.
2. 로그인을 진행합니다.
3. 로그인 요청의 헤더 값을 확인합니다.
4. 0. ~ 3.을 앱을 유지한 상황에서 진행합니다. Device ID가 같음을 확인합니다.
5. 앱을 삭제합니다.
6. 0. ~ 3.을 다시 진행합니다. Device ID가 다름을 확인합니다.


## Other information:

### Sample Device ID
```markdown
> init
device-id:          1475a237-93ad-4c24-adc4-033b065c00f4
> re-launch
device-id:          1475a237-93ad-4c24-adc4-033b065c00f4
-- re-install  --
> after re-install
device-id:          805ddff7-4f35-421a-90d8-805367e67b28
```

### Custom-Header 도입 사유

- 로그인/회원가입이 아닌 일부 다른 엔드포인트에서도 Device ID를 요구합니다.
  - 노트 단건 조회
  - 추후 추가될 이벤트 관련 API

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic device identification: generates and persistently stores a stable device ID used for authentication.

* **Chores**
  * Authentication flows updated to automatically include device identification for sign-in and sign-up.
  * Updated Android backup and data extraction rules to exclude the stored device identifier from system backups and transfers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->