### PR TITLE
SCRUM-246 feature: connect signup to server

### DIFF
--- a/app/src/main/java/com/lyrics/feelin/core/data/repository/AuthRepository.kt
+++ b/app/src/main/java/com/lyrics/feelin/core/data/repository/AuthRepository.kt
@@ -13,6 +13,7 @@ import com.lyrics.feelin.util.toServerErrorDto
 import java.net.HttpURLConnection
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.StateFlow
 import retrofit2.HttpException
 
@@ -179,24 +180,37 @@ class AuthRepository @Inject constructor(
     // ========== 회원가입 ==========
 
     suspend fun signUp(signUpData: SignUpData): Result<Unit> {
-        val tokenResult =
-            authRemoteDataSource.signUp(signUpData = signUpData).onFailure {
-                if (it is HttpException) {
-                    return Result.failure(
-                        exception = FeelinServerException(description = it.toServerErrorDto()),
-                    )
+        val tokenResult = authRemoteDataSource.signUp(signUpData = signUpData)
+        val failure = tokenResult.exceptionOrNull()?.let(::mapSignUpFailure)
+
+        if (failure != null) {
+            return Result.failure(exception = failure)
+        }
+
+        val token = tokenResult.getOrThrow()
+        return runCatching {
+            authManager.saveServerToken(
+                accessToken = token.accessToken,
+                refreshToken = token.refreshToken,
+                userId = token.userId,
+            )
+        }.fold(
+            onSuccess = { Result.success(Unit) },
+            onFailure = { exception ->
+                if (exception is CancellationException) {
+                    throw exception
                 }
-                return Result.failure(exception = it)
-            }
-
-        val token = tokenResult.getOrNull()!!
-        authManager.saveServerToken(
-            accessToken = token.accessToken,
-            refreshToken = token.refreshToken,
-            userId = token.userId,
+                Result.failure(exception = exception)
+            },
         )
+    }
 
-        return Result.success(Unit)
+    private fun mapSignUpFailure(throwable: Throwable): Throwable {
+        return if (throwable is HttpException) {
+            FeelinServerException(description = throwable.toServerErrorDto())
+        } else {
+            throwable
+        }
     }
 
     // ========== 회원탈퇴 ==========

--- a/app/src/main/java/com/lyrics/feelin/core/data/repository/AuthRepository.kt
+++ b/app/src/main/java/com/lyrics/feelin/core/data/repository/AuthRepository.kt
@@ -181,6 +181,11 @@ class AuthRepository @Inject constructor(
     suspend fun signUp(signUpData: SignUpData): Result<Unit> {
         val tokenResult =
             authRemoteDataSource.signUp(signUpData = signUpData).onFailure {
+                if (it is HttpException) {
+                    return Result.failure(
+                        exception = FeelinServerException(description = it.toServerErrorDto()),
+                    )
+                }
                 return Result.failure(exception = it)
             }
 

--- a/app/src/main/java/com/lyrics/feelin/core/data/repository/UserRepository.kt
+++ b/app/src/main/java/com/lyrics/feelin/core/data/repository/UserRepository.kt
@@ -6,6 +6,8 @@ import javax.inject.Inject
 import javax.inject.Singleton
 import kotlinx.coroutines.flow.Flow
 
+// TODO(@이대근): 앱을 사용할때만 보여주도록(회원정보 화면 등) 인메모리 저장소 기반으로 변경 2026.05.03.
+
 @Singleton
 class UserRepository @Inject constructor(
     private val userPreferencesDataStore: UserPreferencesDataStore

--- a/app/src/main/java/com/lyrics/feelin/core/designsystem/component/ProfileCharacter.kt
+++ b/app/src/main/java/com/lyrics/feelin/core/designsystem/component/ProfileCharacter.kt
@@ -2,36 +2,42 @@ package com.lyrics.feelin.core.designsystem.component
 
 import androidx.annotation.DrawableRes
 import com.lyrics.feelin.R
+import com.lyrics.feelin.core.domain.model.ProfileType
 
 /**
  * 프로필 캐릭터
  */
 enum class ProfileCharacter(
     val id: Int,
+    val profileType: ProfileType,
     @DrawableRes val activatedRes: Int,
     @DrawableRes val darkInactiveRes: Int,
     @DrawableRes val lightInactiveRes: Int
 ) {
     PROFILE_1(
         id = 1,
+        profileType = ProfileType.SHORT_HAIR,
         activatedRes = R.drawable.profile_1_activated,
         darkInactiveRes = R.drawable.profile_1_dark_inactive,
         lightInactiveRes = R.drawable.profile_1_light_inactive
     ),
     PROFILE_2(
         id = 2,
+        profileType = ProfileType.BRAIDED_HAIR,
         activatedRes = R.drawable.profile_2_activated,
         darkInactiveRes = R.drawable.profile_2_dark_inactive,
         lightInactiveRes = R.drawable.profile_2_light_inactive
     ),
     PROFILE_3(
         id = 3,
+        profileType = ProfileType.PARTED_HAIR,
         activatedRes = R.drawable.profile_3_activated,
         darkInactiveRes = R.drawable.profile_3_dark_inactive,
         lightInactiveRes = R.drawable.profile_3_light_inactive
     ),
     PROFILE_4(
         id = 4,
+        profileType = ProfileType.POOP_HAIR,
         activatedRes = R.drawable.profile_4_activated,
         darkInactiveRes = R.drawable.profile_4_dark_inactive,
         lightInactiveRes = R.drawable.profile_4_light_inactive

--- a/app/src/main/java/com/lyrics/feelin/core/domain/model/ProfileType.kt
+++ b/app/src/main/java/com/lyrics/feelin/core/domain/model/ProfileType.kt
@@ -1,11 +1,19 @@
 package com.lyrics.feelin.core.domain.model
 
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
 enum class ProfileType {
+    @SerialName("shortHair")
     SHORT_HAIR,
+
+    @SerialName("braidedHair")
     BRAIDED_HAIR,
+
+    @SerialName("partedHair")
     PARTED_HAIR,
+
+    @SerialName("poopHair")
     POOP_HAIR,
 }

--- a/app/src/main/java/com/lyrics/feelin/core/domain/model/SignUpData.kt
+++ b/app/src/main/java/com/lyrics/feelin/core/domain/model/SignUpData.kt
@@ -8,8 +8,8 @@ data class SignUpData(
     val authProvider: OAuthProvider,
     val nickname: String,
     val profileCharacter: ProfileType,
-    val gender: Gender,
-    val birthYear: String,
+    val gender: Gender?,
+    val birthYear: String?,
     val terms: List<TermAgreementStatus>,
     val isAdmin: Boolean = false,
 )

--- a/app/src/main/java/com/lyrics/feelin/core/domain/model/SignUpTerm.kt
+++ b/app/src/main/java/com/lyrics/feelin/core/domain/model/SignUpTerm.kt
@@ -1,5 +1,11 @@
 package com.lyrics.feelin.core.domain.model
 
+/**
+ * 회원가입 약관 UI와 서버 전송 payload를 함께 정의한다.
+ *
+ * enum 선언 순서는 OnboardingTermsScreen 표시 순서이자
+ * SignUpData.terms 생성 순서로 그대로 사용되므로 서버 계약 변경 없이 재정렬하지 않는다.
+ */
 enum class SignUpTerm(
     val title: String,
     val agreement: String,

--- a/app/src/main/java/com/lyrics/feelin/core/domain/model/SignUpTerm.kt
+++ b/app/src/main/java/com/lyrics/feelin/core/domain/model/SignUpTerm.kt
@@ -1,0 +1,28 @@
+package com.lyrics.feelin.core.domain.model
+
+enum class SignUpTerm(
+    val title: String,
+    val agreement: String,
+    val required: Boolean = true,
+) {
+    AGE_AGREEMENT(
+        title = "만 14세 이상 가입 동의",
+        agreement = "",
+    ),
+    SERVICE_USAGE(
+        title = "서비스 이용약관 동의",
+        agreement = "https://www.notion.so/Feelin-424aa52fb951444fa95f3966672ec670?pvs=4",
+    ),
+    PERSONAL_INFO(
+        title = "개인정보처리방침 동의",
+        agreement = "https://www.notion.so/Feelin-2f586ef1b7c947d89ad8cac8a83b61d1?pvs=4",
+    );
+
+    fun toAgreementStatus(agree: Boolean): TermAgreementStatus {
+        return TermAgreementStatus(
+            agree = agree,
+            title = title,
+            agreement = agreement,
+        )
+    }
+}

--- a/app/src/main/java/com/lyrics/feelin/navigation/FeelinNavHost.kt
+++ b/app/src/main/java/com/lyrics/feelin/navigation/FeelinNavHost.kt
@@ -130,12 +130,10 @@ private fun NavGraphBuilder.onboardingGenderAgeScreen(navController: NavHostCont
             OnboardingGenderAgeScreen(
                 onBackClick = { navController.popBackStack() },
                 onSkipClick = {
-                    // TODO(@이대근): 화면 이동 이외 부분을 화면 내부에 연결 2026.05.03.
                     viewModel.clearGenderAndBirthYear()
                     navController.navigate(FeelinDestination.OnboardingProfile.route)
                 },
                 onNextClick = { gender, birthYear ->
-                    // TODO(@이대근): 화면 이동 이외 부분을 화면 내부에 연결 2026.05.03.
                     viewModel.saveGenderAndBirthYear(gender, birthYear)
                     navController.navigate(FeelinDestination.OnboardingProfile.route)
                 }

--- a/app/src/main/java/com/lyrics/feelin/navigation/FeelinNavHost.kt
+++ b/app/src/main/java/com/lyrics/feelin/navigation/FeelinNavHost.kt
@@ -162,7 +162,17 @@ private fun NavGraphBuilder.onboardingProfileScreen(navController: NavHostContro
                 isLoading = onboardingUiState is OnboardingUiState.SigningUp,
                 errorTitle = (onboardingUiState as? OnboardingUiState.Error)?.title,
                 errorDescription = (onboardingUiState as? OnboardingUiState.Error)?.description,
-                onErrorConfirmClick = viewModel::clearOnboardingUiState,
+                onErrorConfirmClick = {
+                    val errorState = onboardingUiState as? OnboardingUiState.Error
+                    viewModel.clearOnboardingUiState()
+
+                    if (errorState?.kind == OnboardingUiState.Kind.MissingRequiredTerms) {
+                        navController.navigate(FeelinDestination.OnboardingTerms.route) {
+                            popUpTo(FeelinDestination.OnboardingTerms.route) { inclusive = false }
+                            launchSingleTop = true
+                        }
+                    }
+                },
             )
         }
     }

--- a/app/src/main/java/com/lyrics/feelin/navigation/FeelinNavHost.kt
+++ b/app/src/main/java/com/lyrics/feelin/navigation/FeelinNavHost.kt
@@ -80,10 +80,16 @@ private fun NavGraphBuilder.onboardingNavGraph(navController: NavHostController)
 }
 
 private fun NavGraphBuilder.loginScreen(navController: NavHostController) {
-    composable(FeelinDestination.Login.route) {
+    composable(FeelinDestination.Login.route) { backStackEntry ->
+        val parentEntry = remember(backStackEntry) {
+            navController.getBackStackEntry(FeelinDestination.OnboardingGraph.route)
+        }
+        val viewModel: OnboardingViewModel = hiltViewModel(parentEntry)
+
         OnboardingScaffold {
             LoginScreen(
                 onSignUp = {
+                    viewModel.resetOnboardingState()
                     navController.navigate(FeelinDestination.OnboardingTerms.route)
                 },
                 onContinueToMain = { navController.navigateToMainGraph() }
@@ -124,10 +130,12 @@ private fun NavGraphBuilder.onboardingGenderAgeScreen(navController: NavHostCont
             OnboardingGenderAgeScreen(
                 onBackClick = { navController.popBackStack() },
                 onSkipClick = {
+                    // TODO(@이대근): 화면 이동 이외 부분을 화면 내부에 연결 2026.05.03.
                     viewModel.clearGenderAndBirthYear()
                     navController.navigate(FeelinDestination.OnboardingProfile.route)
                 },
                 onNextClick = { gender, birthYear ->
+                    // TODO(@이대근): 화면 이동 이외 부분을 화면 내부에 연결 2026.05.03.
                     viewModel.saveGenderAndBirthYear(gender, birthYear)
                     navController.navigate(FeelinDestination.OnboardingProfile.route)
                 }

--- a/app/src/main/java/com/lyrics/feelin/navigation/FeelinNavHost.kt
+++ b/app/src/main/java/com/lyrics/feelin/navigation/FeelinNavHost.kt
@@ -11,6 +11,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
@@ -40,6 +42,7 @@ import com.lyrics.feelin.presentation.view.mypage.setting.SettingScreen
 import com.lyrics.feelin.presentation.view.mypage.userinfo.UserInfoScreen
 import com.lyrics.feelin.presentation.view.note.search.NoteSearchScreen
 import com.lyrics.feelin.presentation.view.note.search.result.NoteSearchResultScreen
+import com.lyrics.feelin.presentation.view.onboarding.OnboardingUiState
 import com.lyrics.feelin.presentation.view.onboarding.OnboardingViewModel
 import com.lyrics.feelin.presentation.view.onboarding.genderage.OnboardingGenderAgeScreen
 import com.lyrics.feelin.presentation.view.onboarding.profile.ProfileScreen
@@ -90,11 +93,21 @@ private fun NavGraphBuilder.loginScreen(navController: NavHostController) {
 }
 
 private fun NavGraphBuilder.onboardingTermsScreen(navController: NavHostController) {
-    composable(FeelinDestination.OnboardingTerms.route) {
+    composable(FeelinDestination.OnboardingTerms.route) { backStackEntry ->
+        val parentEntry = remember(backStackEntry) {
+            navController.getBackStackEntry(FeelinDestination.OnboardingGraph.route)
+        }
+        val viewModel: OnboardingViewModel = hiltViewModel(parentEntry)
+        val onboardingState by viewModel.onboardingState.collectAsState()
+
         OnboardingScaffold {
             OnboardingTermsScreen(
                 onBackClick = { navController.popBackStack() },
-                onStartClick = { navController.navigate(FeelinDestination.OnboardingGenderAge.route) }
+                onStartClick = { navController.navigate(FeelinDestination.OnboardingGenderAge.route) },
+                termAgreements = onboardingState.termAgreements,
+                onAllCheckedChange = viewModel::setAllTermsAgreed,
+                onTermCheckedChange = viewModel::setTermAgreed,
+                onDetailClick = {},
             )
         }
     }
@@ -110,7 +123,10 @@ private fun NavGraphBuilder.onboardingGenderAgeScreen(navController: NavHostCont
         OnboardingScaffold {
             OnboardingGenderAgeScreen(
                 onBackClick = { navController.popBackStack() },
-                onSkipClick = { navController.navigate(FeelinDestination.OnboardingProfile.route) },
+                onSkipClick = {
+                    viewModel.clearGenderAndBirthYear()
+                    navController.navigate(FeelinDestination.OnboardingProfile.route)
+                },
                 onNextClick = { gender, birthYear ->
                     viewModel.saveGenderAndBirthYear(gender, birthYear)
                     navController.navigate(FeelinDestination.OnboardingProfile.route)
@@ -126,30 +142,37 @@ private fun NavGraphBuilder.onboardingProfileScreen(navController: NavHostContro
             navController.getBackStackEntry(FeelinDestination.OnboardingGraph.route)
         }
         val viewModel: OnboardingViewModel = hiltViewModel(parentEntry)
+        val onboardingUiState by viewModel.onboardingUiState.collectAsState()
+
+        LaunchedEffect(onboardingUiState) {
+            if (onboardingUiState is OnboardingUiState.SignUpSuccess) {
+                viewModel.clearOnboardingUiState()
+                navController.navigate(FeelinDestination.OnboardingWelcome.route) {
+                    popUpTo(FeelinDestination.OnboardingProfile.route) { inclusive = true }
+                }
+            }
+        }
 
         OnboardingScaffold {
             ProfileScreen(
                 onBackClick = { navController.popBackStack() },
-                onCompleteClick = { nickname, profileIndex ->
-                    viewModel.saveProfile(nickname, profileIndex)
-                    navController.navigate(FeelinDestination.OnboardingWelcome.route)
-                }
+                onCompleteClick = { nickname, profileType ->
+                    viewModel.signUp(nickname, profileType)
+                },
+                isLoading = onboardingUiState is OnboardingUiState.SigningUp,
+                errorTitle = (onboardingUiState as? OnboardingUiState.Error)?.title,
+                errorDescription = (onboardingUiState as? OnboardingUiState.Error)?.description,
+                onErrorConfirmClick = viewModel::clearOnboardingUiState,
             )
         }
     }
 }
 
 private fun NavGraphBuilder.onboardingWelcomeScreen(navController: NavHostController) {
-    composable(FeelinDestination.OnboardingWelcome.route) { backStackEntry ->
-        val parentEntry = remember(backStackEntry) {
-            navController.getBackStackEntry(FeelinDestination.OnboardingGraph.route)
-        }
-        val viewModel: OnboardingViewModel = hiltViewModel(parentEntry)
-
+    composable(FeelinDestination.OnboardingWelcome.route) {
         OnboardingScaffold {
             WelcomeScreen(
                 onNavigateToMain = {
-                    viewModel.completeOnboarding()
                     navController.navigateToMainGraph()
                 }
             )

--- a/app/src/main/java/com/lyrics/feelin/presentation/view/onboarding/OnboardingUiState.kt
+++ b/app/src/main/java/com/lyrics/feelin/presentation/view/onboarding/OnboardingUiState.kt
@@ -1,0 +1,30 @@
+package com.lyrics.feelin.presentation.view.onboarding
+
+import com.lyrics.feelin.core.domain.model.ProfileType
+import com.lyrics.feelin.core.domain.model.SignUpTerm
+
+data class OnboardingState(
+    val termAgreements: Map<SignUpTerm, Boolean> = SignUpTerm.entries.associateWith { false },
+    val gender: String? = null,
+    val birthYear: Int? = null,
+    val nickname: String = "",
+    val profileType: ProfileType = ProfileType.SHORT_HAIR,
+) {
+    val isStartEnabled: Boolean
+        get() = SignUpTerm.entries
+            .filter { it.required }
+            .all { termAgreements[it] == true }
+}
+
+sealed interface OnboardingUiState {
+    data object Idle : OnboardingUiState
+
+    data object SigningUp : OnboardingUiState
+
+    data object SignUpSuccess : OnboardingUiState
+
+    data class Error(
+        val title: String,
+        val description: String,
+    ) : OnboardingUiState
+}

--- a/app/src/main/java/com/lyrics/feelin/presentation/view/onboarding/OnboardingUiState.kt
+++ b/app/src/main/java/com/lyrics/feelin/presentation/view/onboarding/OnboardingUiState.kt
@@ -26,5 +26,12 @@ sealed interface OnboardingUiState {
     data class Error(
         val title: String,
         val description: String,
+        val kind: Kind,
     ) : OnboardingUiState
+
+    sealed interface Kind {
+        data object MissingRequiredTerms : Kind
+
+        data object General : Kind
+    }
 }

--- a/app/src/main/java/com/lyrics/feelin/presentation/view/onboarding/OnboardingViewModel.kt
+++ b/app/src/main/java/com/lyrics/feelin/presentation/view/onboarding/OnboardingViewModel.kt
@@ -59,6 +59,10 @@ class OnboardingViewModel @Inject constructor(
     }
 
     fun signUp(nickname: String, profileType: ProfileType) {
+        if (_onboardingUiState.value is OnboardingUiState.SigningUp) {
+            return
+        }
+
         val oauthAccessToken = authManager.oauthAccessToken.value
         val oauthProvider = authManager.oauthProvider.value
         val updatedState = _onboardingState.value.copy(

--- a/app/src/main/java/com/lyrics/feelin/presentation/view/onboarding/OnboardingViewModel.kt
+++ b/app/src/main/java/com/lyrics/feelin/presentation/view/onboarding/OnboardingViewModel.kt
@@ -1,5 +1,6 @@
 package com.lyrics.feelin.presentation.view.onboarding
 
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.lyrics.feelin.core.data.datasource.remote.dto.exception.FeelinServerException
@@ -16,6 +17,8 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+
+private const val TAG = "OnboardingViewModel"
 
 @HiltViewModel
 class OnboardingViewModel @Inject constructor(
@@ -102,9 +105,10 @@ class OnboardingViewModel @Inject constructor(
                             profileType = profileType,
                             state = updatedState,
                         )
-                    }.onSuccess {
-                        _onboardingUiState.value = OnboardingUiState.SignUpSuccess
-                    }.onFailure(::updateSignUpError)
+                    }.onFailure { error ->
+                        Log.e(TAG, "Failed to sync local onboarding cache after signup", error)
+                    }
+                    _onboardingUiState.value = OnboardingUiState.SignUpSuccess
                 }
                 .onFailure(::updateSignUpError)
         }

--- a/app/src/main/java/com/lyrics/feelin/presentation/view/onboarding/OnboardingViewModel.kt
+++ b/app/src/main/java/com/lyrics/feelin/presentation/view/onboarding/OnboardingViewModel.kt
@@ -106,6 +106,8 @@ class OnboardingViewModel @Inject constructor(
                             state = updatedState,
                         )
                     }.onFailure { error ->
+                        // 서버 회원가입과 JWT 저장이 이미 끝난 상태라서,
+                        // 임시 로컬 캐시 동기화 실패만으로 가입 완료 플로우를 되돌리지 않는다.
                         Log.e(TAG, "Failed to sync local onboarding cache after signup", error)
                     }
                     _onboardingUiState.value = OnboardingUiState.SignUpSuccess

--- a/app/src/main/java/com/lyrics/feelin/presentation/view/onboarding/OnboardingViewModel.kt
+++ b/app/src/main/java/com/lyrics/feelin/presentation/view/onboarding/OnboardingViewModel.kt
@@ -70,6 +70,7 @@ class OnboardingViewModel @Inject constructor(
             _onboardingUiState.value = OnboardingUiState.Error(
                 title = "필수 약관 동의가 필요해요.",
                 description = "에러코드 [-1]",
+                kind = OnboardingUiState.Kind.MissingRequiredTerms,
             )
             return
         }
@@ -78,6 +79,7 @@ class OnboardingViewModel @Inject constructor(
             _onboardingUiState.value = OnboardingUiState.Error(
                 title = "회원가입에 필요한 로그인 정보가 없어요.",
                 description = "에러코드 [-1]",
+                kind = OnboardingUiState.Kind.General,
             )
             return
         }
@@ -143,11 +145,13 @@ class OnboardingViewModel @Inject constructor(
             OnboardingUiState.Error(
                 title = throwable.description.errorMessage,
                 description = "에러코드 [${throwable.description.errorCode}]",
+                kind = OnboardingUiState.Kind.General,
             )
         } else {
             OnboardingUiState.Error(
                 title = "회원가입 시도중 오류가 발생했어요.",
                 description = "에러코드 [-1]",
+                kind = OnboardingUiState.Kind.General,
             )
         }
     }

--- a/app/src/main/java/com/lyrics/feelin/presentation/view/onboarding/OnboardingViewModel.kt
+++ b/app/src/main/java/com/lyrics/feelin/presentation/view/onboarding/OnboardingViewModel.kt
@@ -2,31 +2,147 @@ package com.lyrics.feelin.presentation.view.onboarding
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.lyrics.feelin.core.data.datasource.remote.dto.exception.FeelinServerException
+import com.lyrics.feelin.core.data.manager.AuthManager
+import com.lyrics.feelin.core.data.repository.AuthRepository
 import com.lyrics.feelin.core.data.repository.UserRepository
+import com.lyrics.feelin.core.domain.model.Gender
+import com.lyrics.feelin.core.domain.model.ProfileType
+import com.lyrics.feelin.core.domain.model.SignUpData
+import com.lyrics.feelin.core.domain.model.SignUpTerm
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 
 @HiltViewModel
 class OnboardingViewModel @Inject constructor(
-    private val userRepository: UserRepository
+    private val authRepository: AuthRepository,
+    private val authManager: AuthManager,
+    private val userRepository: UserRepository,
 ) : ViewModel() {
+    private val _onboardingState = MutableStateFlow(OnboardingState())
+    val onboardingState: StateFlow<OnboardingState> = _onboardingState.asStateFlow()
+
+    private val _onboardingUiState = MutableStateFlow<OnboardingUiState>(OnboardingUiState.Idle)
+    val onboardingUiState: StateFlow<OnboardingUiState> = _onboardingUiState.asStateFlow()
+
+    fun setAllTermsAgreed(checked: Boolean) {
+        _onboardingState.value = _onboardingState.value.copy(
+            termAgreements = SignUpTerm.entries.associateWith { checked },
+        )
+    }
+
+    fun setTermAgreed(term: SignUpTerm, checked: Boolean) {
+        _onboardingState.value = _onboardingState.value.copy(
+            termAgreements = _onboardingState.value.termAgreements + (term to checked),
+        )
+    }
 
     fun saveGenderAndBirthYear(gender: String, birthYear: Int) {
+        _onboardingState.value = _onboardingState.value.copy(
+            gender = gender,
+            birthYear = birthYear,
+        )
+    }
+
+    fun clearGenderAndBirthYear() {
+        _onboardingState.value = _onboardingState.value.copy(
+            gender = null,
+            birthYear = null,
+        )
+    }
+
+    fun signUp(nickname: String, profileType: ProfileType) {
+        val oauthAccessToken = authManager.oauthAccessToken.value
+        val oauthProvider = authManager.oauthProvider.value
+        val updatedState = _onboardingState.value.copy(
+            nickname = nickname,
+            profileType = profileType,
+        )
+
+        if (!updatedState.isStartEnabled) {
+            _onboardingUiState.value = OnboardingUiState.Error(
+                title = "필수 약관 동의가 필요해요.",
+                description = "에러코드 [-1]",
+            )
+            return
+        }
+
+        if (oauthAccessToken.isNullOrBlank() || oauthProvider == null) {
+            _onboardingUiState.value = OnboardingUiState.Error(
+                title = "회원가입에 필요한 로그인 정보가 없어요.",
+                description = "에러코드 [-1]",
+            )
+            return
+        }
+        _onboardingState.value = updatedState
+        _onboardingUiState.value = OnboardingUiState.SigningUp
+
         viewModelScope.launch {
-            userRepository.saveGenderAndBirthYear(gender, birthYear)
+            val signUpData = SignUpData(
+                socialAccessToken = oauthAccessToken,
+                authProvider = oauthProvider,
+                nickname = updatedState.nickname,
+                profileCharacter = updatedState.profileType,
+                gender = updatedState.gender?.let { Gender.fromString(it) },
+                birthYear = updatedState.birthYear?.toString(),
+                terms = SignUpTerm.entries.map { term ->
+                    term.toAgreementStatus(agree = updatedState.termAgreements[term] == true)
+                },
+            )
+
+            authRepository.signUp(signUpData = signUpData)
+                .onSuccess {
+                    runCatching {
+                        syncLocalUserData(
+                            nickname = nickname,
+                            profileType = profileType,
+                            state = updatedState,
+                        )
+                    }.onSuccess {
+                        _onboardingUiState.value = OnboardingUiState.SignUpSuccess
+                    }.onFailure(::updateSignUpError)
+                }
+                .onFailure(::updateSignUpError)
         }
     }
 
-    fun saveProfile(nickname: String, profileIndex: Int) {
-        viewModelScope.launch {
-            userRepository.saveProfile(nickname, profileIndex)
-        }
+    fun clearOnboardingUiState() {
+        _onboardingUiState.value = OnboardingUiState.Idle
     }
 
-    fun completeOnboarding() {
-        viewModelScope.launch {
-            userRepository.completeOnboarding()
+    private suspend fun syncLocalUserData(
+        nickname: String,
+        profileType: ProfileType,
+        state: OnboardingState,
+    ) {
+        if (state.gender != null && state.birthYear != null) {
+            userRepository.saveGenderAndBirthYear(
+                gender = state.gender,
+                birthYear = state.birthYear,
+            )
+        }
+        userRepository.saveProfile(
+            nickname = nickname,
+            profileIndex = profileType.ordinal,
+        )
+        userRepository.completeOnboarding()
+    }
+
+    private fun updateSignUpError(throwable: Throwable) {
+        _onboardingUiState.value = if (throwable is FeelinServerException) {
+            OnboardingUiState.Error(
+                title = throwable.description.errorMessage,
+                description = "에러코드 [${throwable.description.errorCode}]",
+            )
+        } else {
+            OnboardingUiState.Error(
+                title = "회원가입 시도중 오류가 발생했어요.",
+                description = "에러코드 [-1]",
+            )
         }
     }
 }

--- a/app/src/main/java/com/lyrics/feelin/presentation/view/onboarding/OnboardingViewModel.kt
+++ b/app/src/main/java/com/lyrics/feelin/presentation/view/onboarding/OnboardingViewModel.kt
@@ -126,6 +126,11 @@ class OnboardingViewModel @Inject constructor(
         _onboardingUiState.value = OnboardingUiState.Idle
     }
 
+    fun resetOnboardingState() {
+        _onboardingState.value = OnboardingState()
+        _onboardingUiState.value = OnboardingUiState.Idle
+    }
+
     private suspend fun syncLocalUserData(
         nickname: String,
         profileType: ProfileType,

--- a/app/src/main/java/com/lyrics/feelin/presentation/view/onboarding/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/lyrics/feelin/presentation/view/onboarding/profile/ProfileScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.lyrics.feelin.core.designsystem.component.FeelinModalDialog
 import com.lyrics.feelin.core.designsystem.component.FeelinNicknameInputField
 import com.lyrics.feelin.core.designsystem.component.FeelinTopAppBarWithBack
 import com.lyrics.feelin.core.designsystem.component.NicknameValidationResult
@@ -39,6 +40,7 @@ import com.lyrics.feelin.core.designsystem.component.ProfileCharacter
 import com.lyrics.feelin.core.designsystem.component.ProfileCharacterBottomSheet
 import com.lyrics.feelin.core.designsystem.component.validateNickname
 import com.lyrics.feelin.core.designsystem.icon.WritingIcon
+import com.lyrics.feelin.core.domain.model.ProfileType
 import com.lyrics.feelin.presentation.designsystem.theme.FeelinTheme
 import com.lyrics.feelin.presentation.designsystem.theme.FeelinTypography
 import com.lyrics.feelin.presentation.designsystem.theme.LocalFeelinColors
@@ -46,8 +48,12 @@ import com.lyrics.feelin.presentation.designsystem.theme.LocalFeelinColors
 @Composable
 fun ProfileScreen(
     onBackClick: () -> Unit,
-    onCompleteClick: (nickname: String, profileIndex: Int) -> Unit,
-    modifier: Modifier = Modifier
+    onCompleteClick: (nickname: String, profileType: ProfileType) -> Unit,
+    modifier: Modifier = Modifier,
+    isLoading: Boolean = false,
+    errorTitle: String? = null,
+    errorDescription: String? = null,
+    onErrorConfirmClick: () -> Unit = {},
 ) {
     val feelinColors = LocalFeelinColors.current
     val nicknameState = remember { TextFieldState(initialText = "") }
@@ -55,7 +61,8 @@ fun ProfileScreen(
     var selectedProfile by remember { mutableStateOf(ProfileCharacter.PROFILE_1) }
 
     val isNicknameValid = nicknameState.text.isNotEmpty() &&
-        validateNickname(nicknameState.text) == NicknameValidationResult.Valid
+        validateNickname(nicknameState.text) == NicknameValidationResult.Valid &&
+        !isLoading
 
     Column(
         modifier = modifier
@@ -118,7 +125,12 @@ fun ProfileScreen(
             CompleteButton(
                 text = "완료",
                 enabled = isNicknameValid,
-                onClick = { onCompleteClick(nicknameState.text.toString(), selectedProfile.ordinal) }
+                onClick = {
+                    onCompleteClick(
+                        nicknameState.text.toString(),
+                        selectedProfile.profileType,
+                    )
+                }
             )
 
             Spacer(modifier = Modifier.height(16.dp))
@@ -133,6 +145,16 @@ fun ProfileScreen(
                 showBottomSheet = false
             },
             selectedProfile = selectedProfile
+        )
+    }
+
+    if (errorTitle != null && errorDescription != null) {
+        FeelinModalDialog(
+            title = errorTitle,
+            description = errorDescription,
+            confirmButtonText = "확인",
+            onConfirmButtonClick = onErrorConfirmClick,
+            isDismissButtonEnable = false,
         )
     }
 }

--- a/app/src/main/java/com/lyrics/feelin/presentation/view/onboarding/terms/OnboardingTermsScreen.kt
+++ b/app/src/main/java/com/lyrics/feelin/presentation/view/onboarding/terms/OnboardingTermsScreen.kt
@@ -13,16 +13,13 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.lyrics.feelin.core.designsystem.component.FeelinCheckboxAllAgree
 import com.lyrics.feelin.core.designsystem.component.FeelinCheckboxItem
 import com.lyrics.feelin.core.designsystem.component.FeelinTopAppBarWithBack
+import com.lyrics.feelin.core.domain.model.SignUpTerm
 import com.lyrics.feelin.presentation.designsystem.theme.FeelinTheme
 import com.lyrics.feelin.presentation.designsystem.theme.FeelinTypography
 import com.lyrics.feelin.presentation.designsystem.theme.LocalFeelinColors
@@ -31,123 +28,89 @@ import com.lyrics.feelin.presentation.designsystem.theme.LocalFeelinColors
 fun OnboardingTermsScreen(
     onBackClick: () -> Unit,
     onStartClick: () -> Unit,
+    termAgreements: Map<SignUpTerm, Boolean>,
+    onAllCheckedChange: (Boolean) -> Unit,
+    onTermCheckedChange: (SignUpTerm, Boolean) -> Unit,
+    onDetailClick: (SignUpTerm) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     FeelinTheme(darkTheme = false) {
         val feelinColors = LocalFeelinColors.current
-
-        // 체크박스 상태 관리
-        var allChecked by remember { mutableStateOf(false) }
-        var ageChecked by remember { mutableStateOf(false) }
-        var serviceChecked by remember { mutableStateOf(false) }
-        var privacyChecked by remember { mutableStateOf(false) }
-
-        // 전체동의 체크시 모두 체크
-        val updateAllChecks = { checked: Boolean ->
-            allChecked = checked
-            ageChecked = checked
-            serviceChecked = checked
-            privacyChecked = checked
-        }
-
-        // 개별 항목 체크시 전체동의 상태 업데이트
-        val updateIndividualCheck = {
-            allChecked = ageChecked && serviceChecked && privacyChecked
-        }
-
-        // 버튼 활성화 조건: 필수 항목(나이, 서비스, 개인정보) 모두 체크
-        val isButtonEnabled = ageChecked && serviceChecked && privacyChecked
+        val allChecked = SignUpTerm.entries
+            .filter { it.required }
+            .all { termAgreements[it] == true }
 
         Column(
             modifier = modifier
                 .fillMaxSize()
-                .background(color = feelinColors.gray00)
+                .background(color = feelinColors.gray00),
         ) {
             FeelinTopAppBarWithBack(
                 title = "",
                 onBackClick = onBackClick,
-                showDivider = false
+                showDivider = false,
             )
 
             Spacer(modifier = Modifier.height(28.dp))
 
             Column(
                 modifier = Modifier
-                    .padding(horizontal = 20.dp)
+                    .padding(horizontal = 20.dp),
             ) {
                 Text(
                     text = "Feelin 이용을 위해 약관을\n동의해주세요",
-                    style = FeelinTypography.heading1
+                    style = FeelinTypography.heading1,
                 )
 
                 Spacer(modifier = Modifier.height(32.dp))
 
                 FeelinCheckboxAllAgree(
                     checked = allChecked,
-                    onCheckedChange = updateAllChecks,
+                    onCheckedChange = onAllCheckedChange,
                     text = "전체동의",
-                    modifier = Modifier.fillMaxWidth()
+                    modifier = Modifier.fillMaxWidth(),
                 )
 
                 Spacer(modifier = Modifier.height(24.dp))
 
-                FeelinCheckboxItem(
-                    checked = ageChecked,
-                    onCheckedChange = { checked ->
-                        ageChecked = checked
-                        updateIndividualCheck()
-                    },
-                    text = "만 14세 이상 가입 동의",
-                    required = true
-                )
+                SignUpTerm.entries.forEachIndexed { index, signUpTerm ->
+                    FeelinCheckboxItem(
+                        checked = termAgreements[signUpTerm] == true,
+                        onCheckedChange = { checked -> onTermCheckedChange(signUpTerm, checked) },
+                        text = signUpTerm.title,
+                        required = signUpTerm.required,
+                        detailText = if (signUpTerm.agreement.isNotBlank()) "보기" else null,
+                        onDetailClick = if (signUpTerm.agreement.isNotBlank()) {
+                            { onDetailClick(signUpTerm) }
+                        } else {
+                            null
+                        },
+                    )
 
-                Spacer(modifier = Modifier.height(12.dp))
-
-                FeelinCheckboxItem(
-                    checked = serviceChecked,
-                    onCheckedChange = { checked ->
-                        serviceChecked = checked
-                        updateIndividualCheck()
-                    },
-                    text = "서비스 이용약관 동의",
-                    required = true,
-                    detailText = "보기",
-                    onDetailClick = {}
-                )
-
-                Spacer(modifier = Modifier.height(12.dp))
-
-                FeelinCheckboxItem(
-                    checked = privacyChecked,
-                    onCheckedChange = { checked ->
-                        privacyChecked = checked
-                        updateIndividualCheck()
-                    },
-                    text = "개인정보처리방침 동의",
-                    required = true,
-                    detailText = "보기",
-                    onDetailClick = {}
-                )
+                    if (index < SignUpTerm.entries.lastIndex) {
+                        Spacer(modifier = Modifier.height(12.dp))
+                    }
+                }
 
                 Spacer(modifier = Modifier.weight(1f))
 
                 Button(
                     onClick = onStartClick,
-                    enabled = isButtonEnabled,
+                    enabled = allChecked,
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(bottom = 24.dp)
                         .height(56.dp),
                     colors = ButtonDefaults.buttonColors(
                         containerColor = feelinColors.systemActivate,
-                        disabledContainerColor = feelinColors.systemDisable
+                        disabledContainerColor = feelinColors.systemDisable,
                     ),
-                    shape = RoundedCornerShape(12.dp)
+                    shape = RoundedCornerShape(12.dp),
                 ) {
                     Text(
                         text = "시작하기",
                         style = FeelinTypography.title2,
-                        color = feelinColors.gray00
+                        color = feelinColors.gray00,
                     )
                 }
             }
@@ -157,19 +120,23 @@ fun OnboardingTermsScreen(
 
 @Preview(
     name = "Onboarding term check screen",
-    showBackground = true
+    showBackground = true,
 )
 @Preview(
     name = "Onboarding term check screen - Dark Mode",
     showBackground = true,
-    uiMode = UI_MODE_NIGHT_YES
+    uiMode = UI_MODE_NIGHT_YES,
 )
 @Composable
 private fun OnboardingTermsScreenPreview() {
     FeelinTheme {
         OnboardingTermsScreen(
             onBackClick = {},
-            onStartClick = {}
+            onStartClick = {},
+            termAgreements = SignUpTerm.entries.associateWith { false },
+            onAllCheckedChange = {},
+            onTermCheckedChange = { _, _ -> },
+            onDetailClick = {},
         )
     }
 }

--- a/app/src/test/java/com/lyrics/feelin/OnboardingSignUpSerializationTest.kt
+++ b/app/src/test/java/com/lyrics/feelin/OnboardingSignUpSerializationTest.kt
@@ -1,0 +1,47 @@
+package com.lyrics.feelin
+
+import com.lyrics.feelin.core.domain.model.OAuthProvider
+import com.lyrics.feelin.core.domain.model.ProfileType
+import com.lyrics.feelin.core.domain.model.SignUpData
+import com.lyrics.feelin.core.domain.model.SignUpTerm
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class OnboardingSignUpSerializationTest {
+    @Test
+    fun `signup data serializes profile type as camel case`() {
+        val signUpData = SignUpData(
+            socialAccessToken = "token",
+            authProvider = OAuthProvider.KAKAO,
+            nickname = "feelin",
+            profileCharacter = ProfileType.SHORT_HAIR,
+            gender = null,
+            birthYear = null,
+            terms = listOf(SignUpTerm.AGE_AGREEMENT.toAgreementStatus(agree = true)),
+        )
+
+        val serialized = Json.encodeToString(SignUpData.serializer(), signUpData)
+
+        assertTrue(serialized.contains("\"profileCharacter\":\"shortHair\""))
+    }
+
+    @Test
+    fun `signup terms map to server payload in enum order`() {
+        val agreements = SignUpTerm.entries.map { it.toAgreementStatus(agree = true) }
+
+        assertEquals("만 14세 이상 가입 동의", agreements[0].title)
+        assertEquals("", agreements[0].agreement)
+        assertEquals("서비스 이용약관 동의", agreements[1].title)
+        assertEquals(
+            "https://www.notion.so/Feelin-424aa52fb951444fa95f3966672ec670?pvs=4",
+            agreements[1].agreement,
+        )
+        assertEquals("개인정보처리방침 동의", agreements[2].title)
+        assertEquals(
+            "https://www.notion.so/Feelin-2f586ef1b7c947d89ad8cac8a83b61d1?pvs=4",
+            agreements[2].agreement,
+        )
+    }
+}


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] The commit message follows our guidelines
<!-- - [ ] Tests for the changes have been added (for bug fixes / features) ~~  -->
<!-- - [ ] Docs have been added / updated (for bug fixes / features) -->


## What kind of change does this PR introduce?

- Add feature


# What is the current behavior?
>  You can also link to an open issue here

회원가입이 로컬에 더미 상태를 넣는 방식으로 구현됨.


# What is the new behavior (if this is a feature change)?

실제 서버의 회원가입 엔드포인트를 호출해 실제로 회원가입이 진행되도록 함



## Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No breaking Changes.



## ScreenShots (If needed)
<p>
  <img src="", width="300" />
</p>



## Other information:

실제 카카오 계정을 이용해 수동 E2E 테스트를 진행했습니다(성별/생년월일 입력 건너뛰기). 해당 과정에서 정상적으로 회원가입 되었습니다.
성별/생년월일을 입력하는 경우까지 수동 E2E 테스트를 진행하겠습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sign-up: gender and birth year optional, explicit profile types (serialized as expected), and structured sign-up terms with per-term controls.
  * Onboarding: centralized UI state (loading/error), term-driven start enablement, navigation flows updated.
  * Profile screen: returns profile type, validates nickname/loading, shows modal error dialog.

* **Bug Fixes**
  * Better mapping and surfacing of sign-up/server errors; improved signup token handling.

* **Tests**
  * Added serialization tests for sign-up payloads and term ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->