### PR TITLE
SCRUM-233 feat: Add profile edit screen

### DIFF
--- a/app/src/main/java/com/lyrics/feelin/core/designsystem/component/FeelinNicknameInputField.kt
+++ b/app/src/main/java/com/lyrics/feelin/core/designsystem/component/FeelinNicknameInputField.kt
@@ -152,9 +152,9 @@ private fun FeelinNicknameInputFieldPreview() {
 private fun FeelinNicknameInvalidPreview() {
     FeelinTheme {
         FeelinNicknameInputField(
-
             state = TextFieldState(initialText = ""),
-            placeholder = "닉네임"
+            placeholder = "닉네임",
+            isEnabled = false
         )
     }
 }

--- a/app/src/main/java/com/lyrics/feelin/core/designsystem/component/FeelinNicknameInputField.kt
+++ b/app/src/main/java/com/lyrics/feelin/core/designsystem/component/FeelinNicknameInputField.kt
@@ -49,11 +49,12 @@ fun FeelinNicknameInputField(
     state: TextFieldState,
     modifier: Modifier = Modifier,
     placeholder: String = "",
-    onClearClick: () -> Unit = {}
+    onClearClick: () -> Unit = {},
+    isEnabled: Boolean = true
 ) {
     val feelinColors = LocalFeelinColors.current
 
-    val textColor = feelinColors.gray08
+    val textColor = if (isEnabled) feelinColors.gray08 else feelinColors.gray03
     val placeholderColor = feelinColors.gray03
     val clearButtonColor = feelinColors.gray03
     val errorColor = feelinColors.alertWarning
@@ -71,7 +72,6 @@ fun FeelinNicknameInputField(
 
     BasicTextField(
         state = state,
-        modifier = modifier,
         lineLimits = TextFieldLineLimits.SingleLine,
         keyboardOptions = KeyboardOptions(
             imeAction = ImeAction.Done,
@@ -95,7 +95,8 @@ fun FeelinNicknameInputField(
                         clearIconColor = clearButtonColor,
                         innerTextField = innerTextField,
                         onClearButtonClick = { onClearClick.invoke() },
-                        clearButtonInteractionSource = interactionSource
+                        clearButtonInteractionSource = interactionSource,
+                        showClearButton = isEnabled
                     )
                 }
 
@@ -141,6 +142,18 @@ private fun FeelinNicknameInputFieldPreview() {
     FeelinTheme {
         FeelinNicknameInputField(
             state = TextFieldState(initialText = "실리카겔짱"),
+            placeholder = "닉네임"
+        )
+    }
+}
+
+@Preview(name = "비활성화 상태")
+@Composable
+private fun FeelinNicknameInvalidPreview() {
+    FeelinTheme {
+        FeelinNicknameInputField(
+
+            state = TextFieldState(initialText = ""),
             placeholder = "닉네임"
         )
     }

--- a/app/src/main/java/com/lyrics/feelin/core/designsystem/component/FeelinNicknameInputField.kt
+++ b/app/src/main/java/com/lyrics/feelin/core/designsystem/component/FeelinNicknameInputField.kt
@@ -71,6 +71,7 @@ fun FeelinNicknameInputField(
     }
 
     BasicTextField(
+        modifier = modifier,
         state = state,
         lineLimits = TextFieldLineLimits.SingleLine,
         keyboardOptions = KeyboardOptions(

--- a/app/src/main/java/com/lyrics/feelin/core/designsystem/component/InnerTextFieldComponent.kt
+++ b/app/src/main/java/com/lyrics/feelin/core/designsystem/component/InnerTextFieldComponent.kt
@@ -32,7 +32,7 @@ fun RowScope.InnerTextFieldComponent(
     modifier: Modifier = Modifier,
     showClearButton: Boolean = true
 ) {
-    Box(modifier = Modifier.weight(1f)) {
+    Box(modifier = modifier.weight(1f)) {
         if (isTextEmpty) {
             Text(
                 text = placeholder,

--- a/app/src/main/java/com/lyrics/feelin/core/designsystem/component/InnerTextFieldComponent.kt
+++ b/app/src/main/java/com/lyrics/feelin/core/designsystem/component/InnerTextFieldComponent.kt
@@ -29,7 +29,8 @@ fun RowScope.InnerTextFieldComponent(
     innerTextField: @Composable (() -> Unit),
     onClearButtonClick: () -> Unit,
     clearButtonInteractionSource: MutableInteractionSource?,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    showClearButton: Boolean = true
 ) {
     Box(modifier = Modifier.weight(1f)) {
         if (isTextEmpty) {
@@ -43,7 +44,7 @@ fun RowScope.InnerTextFieldComponent(
     }
 
     // 클리어 버튼 (입력값 있을 때만 표시)
-    if (!isTextEmpty) {
+    if (!isTextEmpty && showClearButton) {
         Spacer(modifier = Modifier.width(8.dp))
 
         Icon(

--- a/app/src/main/java/com/lyrics/feelin/presentation/view/mypage/editprofile/EditProfileScreen.kt
+++ b/app/src/main/java/com/lyrics/feelin/presentation/view/mypage/editprofile/EditProfileScreen.kt
@@ -1,0 +1,248 @@
+package com.lyrics.feelin.presentation.view.mypage.editprofile
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.lyrics.feelin.core.designsystem.component.FeelinModalDialog
+import com.lyrics.feelin.core.designsystem.component.FeelinNicknameInputField
+import com.lyrics.feelin.core.designsystem.component.FeelinTopAppBarWithBack
+import com.lyrics.feelin.core.designsystem.component.NicknameValidationResult
+import com.lyrics.feelin.core.designsystem.component.ProfileCharacter
+import com.lyrics.feelin.core.designsystem.component.ProfileCharacterBottomSheet
+import com.lyrics.feelin.core.designsystem.component.validateNickname
+import com.lyrics.feelin.core.designsystem.icon.WritingIcon
+import com.lyrics.feelin.core.domain.model.ProfileType
+import com.lyrics.feelin.presentation.designsystem.theme.FeelinTheme
+import com.lyrics.feelin.presentation.designsystem.theme.FeelinTypography
+import com.lyrics.feelin.presentation.designsystem.theme.LocalFeelinColors
+
+@Composable
+fun EditProfileScreen(
+    onBackClick: () -> Unit,
+    onCompleteClick: (nickname: String, profileType: ProfileType) -> Unit,
+    modifier: Modifier = Modifier,
+    initialNickname: String = "",
+    initialProfileType: ProfileType = ProfileType.SHORT_HAIR,
+    isLoading: Boolean = false,
+    errorTitle: String? = null,
+    errorDescription: String? = null,
+    onErrorConfirmClick: () -> Unit = {},
+) {
+    val feelinColors = LocalFeelinColors.current
+    val nicknameState = remember(initialNickname) {
+        TextFieldState(initialText = initialNickname)
+    }
+    var showBottomSheet by remember { mutableStateOf(false) }
+    var selectedProfile by remember(initialProfileType) {
+        mutableStateOf(initialProfileType.toProfileCharacter())
+    }
+
+    val currentNickname = nicknameState.text.toString()
+    val isNicknameValid = currentNickname.isNotEmpty() &&
+        validateNickname(nicknameState.text) == NicknameValidationResult.Valid &&
+        !isLoading
+    val hasChanges = currentNickname != initialNickname ||
+        selectedProfile.profileType != initialProfileType
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .background(color = feelinColors.gray00)
+    ) {
+        FeelinTopAppBarWithBack(
+            title = "프로필 수정",
+            onBackClick = onBackClick,
+            showDivider = false,
+            actions = {}
+        )
+
+        Spacer(modifier = Modifier.height(28.dp))
+
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 20.dp)
+        ) {
+            Spacer(modifier = Modifier.height(52.dp))
+
+            Box(
+                modifier = Modifier.fillMaxWidth(),
+                contentAlignment = Alignment.Center
+            ) {
+                ProfileImageSelectorWithEdit(
+                    selectedProfile = selectedProfile,
+                    onEditClick = { showBottomSheet = true }
+                )
+            }
+
+            Spacer(modifier = Modifier.height(40.dp))
+
+            Text(
+                text = "*닉네임은 한/영/숫자 상관없이 10자 이내\n(공백, 특수문자, 이모티콘 사용 불가)",
+                style = FeelinTypography.body3,
+                color = feelinColors.gray04
+            )
+
+            Spacer(modifier = Modifier.height(20.dp))
+
+            Row {
+                FeelinNicknameInputField(
+                    state = nicknameState,
+                    modifier = Modifier.fillMaxWidth(),
+                    placeholder = "닉네임",
+                    onClearClick = { nicknameState.edit { replace(0, length, "") } }
+                )
+            }
+
+            Spacer(modifier = Modifier.weight(1f))
+
+            CompleteButton(
+                text = "프로필 저장",
+                enabled = isNicknameValid && hasChanges,
+                onClick = {
+                    onCompleteClick(
+                        currentNickname,
+                        selectedProfile.profileType,
+                    )
+                }
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+        }
+    }
+
+    if (showBottomSheet) {
+        ProfileCharacterBottomSheet(
+            onDismiss = { showBottomSheet = false },
+            onSelectProfile = { profile ->
+                selectedProfile = profile
+                showBottomSheet = false
+            },
+            selectedProfile = selectedProfile
+        )
+    }
+
+    if (errorTitle != null && errorDescription != null) {
+        FeelinModalDialog(
+            title = errorTitle,
+            description = errorDescription,
+            confirmButtonText = "확인",
+            onConfirmButtonClick = onErrorConfirmClick,
+            isDismissButtonEnable = false,
+        )
+    }
+}
+
+@Suppress("MagicNumber")
+private val ProfileImageOverlapOffset = (-36).dp
+
+private fun ProfileType.toProfileCharacter(): ProfileCharacter {
+    return ProfileCharacter.entries.firstOrNull { it.profileType == this }
+        ?: ProfileCharacter.PROFILE_1
+}
+
+@Composable
+private fun ProfileImageSelectorWithEdit(
+    selectedProfile: ProfileCharacter,
+    onEditClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val profileDrawableRes = selectedProfile.getDrawableRes(
+        isSelected = true,
+        isDarkMode = false
+    )
+
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(ProfileImageOverlapOffset, Alignment.Start),
+        verticalAlignment = Alignment.Bottom,
+        modifier = modifier
+    ) {
+        Icon(
+            painter = painterResource(id = profileDrawableRes),
+            contentDescription = null,
+            modifier = Modifier.size(176.dp),
+            tint = Color.Unspecified
+        )
+
+        Box(
+            modifier = Modifier
+                .size(56.dp)
+                .border(5.dp, LocalFeelinColors.current.gray00, CircleShape)
+                .clip(CircleShape)
+                .background(LocalFeelinColors.current.brandPrimary)
+                .clickable { onEditClick() },
+            contentAlignment = Alignment.Center
+        ) {
+            Icon(
+                imageVector = WritingIcon,
+                contentDescription = "프로필 이미지 변경",
+                tint = LocalFeelinColors.current.gray00,
+                modifier = Modifier.size(24.dp)
+            )
+        }
+    }
+}
+
+@Composable
+private fun CompleteButton(text: String, enabled: Boolean, onClick: () -> Unit) {
+    Button(
+        onClick = onClick,
+        enabled = enabled,
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(56.dp),
+        shape = RoundedCornerShape(12.dp),
+        colors = ButtonDefaults.buttonColors(
+            containerColor = LocalFeelinColors.current.systemActivate,
+            disabledContainerColor = LocalFeelinColors.current.systemDisable
+        )
+    ) {
+        Text(
+            text = text,
+            style = FeelinTypography.title2,
+            color = LocalFeelinColors.current.gray00
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun EditProfileScreenPreview() {
+    FeelinTheme {
+        EditProfileScreen(
+            onBackClick = {},
+            onCompleteClick = { _, _ -> },
+            initialNickname = "샘플유저",
+            initialProfileType = ProfileType.BRAIDED_HAIR,
+        )
+    }
+}

--- a/app/src/main/java/com/lyrics/feelin/presentation/view/mypage/editprofile/EditProfileScreen.kt
+++ b/app/src/main/java/com/lyrics/feelin/presentation/view/mypage/editprofile/EditProfileScreen.kt
@@ -119,7 +119,8 @@ fun EditProfileScreen(
                     state = nicknameState,
                     modifier = Modifier.fillMaxWidth(),
                     placeholder = "닉네임",
-                    onClearClick = { nicknameState.edit { replace(0, length, "") } }
+                    onClearClick = { nicknameState.edit { replace(0, length, "") } },
+                    isEnabled = hasChanges
                 )
             }
 


### PR DESCRIPTION
## Please check if the PR fulfills these requirements
- [x] The commit message follows our guidelines
<!-- - [ ] Tests for the changes have been added (for bug fixes / features) ~~  -->
<!-- - [ ] Docs have been added / updated (for bug fixes / features) -->


## What kind of change does this PR introduce?
- Add feature


## What is the current behavior?
- 마이페이지에서 프로필 수정 화면이 없고, 닉네임/프로필 캐릭터를 변경할 수 없습니다.


## What is the new behavior (if this is a feature change)?
- 마이페이지에서 프로필 수정 화면을 열 수 있습니다.
- 프로필 캐릭터 선택 바텀시트를 제공합니다.
- 닉네임 입력 및 검증 로직이 적용됩니다.
- 닉네임 변경 제한 안내 다이얼로그를 지원합니다.
- 라이트/다크 모드를 지원합니다.
- 변경사항이 있을 때만 저장 버튼이 활성화됩니다.


## Does this PR introduce a breaking change?
- No


## ScreenShots (If needed)
<p>
  <img src="https://github.com/user-attachments/assets/d09d8f7c-0698-464b-afe9-88bfc71ca457", width="300" />
</p>


## Other information:
- 닉네임 규칙: 1~10자, 한글/영문/숫자만 허용
- 에러 메시지:
  - 공백, 특수문자, 이모티콘은 사용 불가합니다
  - 1~10자의 닉네임을 사용해주세요
- 닉네임 변경 제한 다이얼로그:
  - 닉네임은 14일 이내 최대 2회까지 변경할 수 있어요.
- TODO:
  - Save API integration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New profile editing screen: edit nickname, pick profile character via bottom sheet, preview profile image, and confirm saves only when nickname is valid and changes exist.
  * Nickname input can be disabled with distinct visual styling; clear button visibility now follows the enabled state and a disabled preview was added.
  * Error dialog shown when both title and description are provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->