### PR TITLE
design: fix bottom modal element border

### DIFF
--- a/app/src/main/java/com/lyrics/feelin/core/designsystem/component/FeelinProfileCharacterBottomSheet.kt
+++ b/app/src/main/java/com/lyrics/feelin/core/designsystem/component/FeelinProfileCharacterBottomSheet.kt
@@ -107,6 +107,55 @@ fun ProfileCharacterBottomSheet(
 }
 
 @Composable
+private fun ProfileCharacterBottomSheetContent(
+    onDismiss: () -> Unit,
+    onSelectProfile: (ProfileCharacter) -> Unit,
+    selectedProfile: ProfileCharacter?,
+    modifier: Modifier = Modifier
+) {
+    val colors = LocalFeelinColors.current
+    val isDarkMode = LocalDarkTheme.current
+    var internalSelectedProfile by remember { mutableStateOf(selectedProfile) }
+
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(top = 24.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 20.dp),
+            verticalArrangement = Arrangement.spacedBy(24.dp)
+        ) {
+            ProfileBottomSheetHeader(
+                onDismiss = onDismiss,
+                titleColor = colors.gray09,
+                iconColor = colors.gray09
+            )
+
+            ProfileCharacterList(
+                selectedProfile = internalSelectedProfile,
+                onProfileClick = { profile -> internalSelectedProfile = profile },
+                isDarkMode = isDarkMode
+            )
+        }
+
+        Spacer(modifier = Modifier.height(32.dp))
+
+        ProfileSelectButton(
+            onClick = { internalSelectedProfile?.let { onSelectProfile(it) } },
+            enabled = internalSelectedProfile != null,
+            backgroundColor = colors.systemActivate,
+            textColor = LightGray00
+        )
+
+        Spacer(modifier = Modifier.height(23.dp))
+    }
+}
+
+@Composable
 private fun ProfileBottomSheetHeader(
     onDismiss: () -> Unit,
     titleColor: Color,
@@ -246,10 +295,10 @@ private fun ProfileSelectButton(
 @Preview(name = "Light Mode - Profile 1 Selected", showBackground = true)
 @Composable
 private fun ProfileCharacterBottomSheetPreviewLight() {
-    var selectedProfile by remember { mutableStateOf(ProfileCharacter.PROFILE_1) }
+    var selectedProfile by remember { mutableStateOf<ProfileCharacter?>(ProfileCharacter.PROFILE_1) }
 
     FeelinTheme(darkTheme = false) {
-        ProfileCharacterBottomSheet(
+        ProfileCharacterBottomSheetContent(
             onDismiss = { },
             onSelectProfile = { selectedProfile = it },
             selectedProfile = selectedProfile
@@ -264,10 +313,10 @@ private fun ProfileCharacterBottomSheetPreviewLight() {
 )
 @Composable
 private fun ProfileCharacterBottomSheetPreviewDark() {
-    var selectedProfile by remember { mutableStateOf(ProfileCharacter.PROFILE_2) }
+    var selectedProfile by remember { mutableStateOf<ProfileCharacter?>(ProfileCharacter.PROFILE_2) }
 
     FeelinTheme(darkTheme = true) {
-        ProfileCharacterBottomSheet(
+        ProfileCharacterBottomSheetContent(
             onDismiss = { },
             onSelectProfile = { selectedProfile = it },
             selectedProfile = selectedProfile
@@ -279,9 +328,10 @@ private fun ProfileCharacterBottomSheetPreviewDark() {
 @Composable
 private fun ProfileCharacterBottomSheetPreviewNoSelection() {
     FeelinTheme(darkTheme = false) {
-        ProfileCharacterBottomSheet(
+        ProfileCharacterBottomSheetContent(
             onDismiss = { },
-            onSelectProfile = { }
+            onSelectProfile = { },
+            selectedProfile = null
         )
     }
 }
@@ -289,13 +339,30 @@ private fun ProfileCharacterBottomSheetPreviewNoSelection() {
 @Preview(name = "Light Mode - Profile 3 Selected", showBackground = true)
 @Composable
 private fun ProfileCharacterBottomSheetPreviewProfile3() {
-    var selectedProfile by remember { mutableStateOf(ProfileCharacter.PROFILE_3) }
+    var selectedProfile by remember { mutableStateOf<ProfileCharacter?>(ProfileCharacter.PROFILE_3) }
 
     FeelinTheme(darkTheme = false) {
-        ProfileCharacterBottomSheet(
+        ProfileCharacterBottomSheetContent(
             onDismiss = { },
             onSelectProfile = { selectedProfile = it },
             selectedProfile = selectedProfile
+        )
+    }
+}
+
+// 좁은 화면에서 레이아웃 확인용 Preview
+@Preview(
+    name = "Narrow Screen (320dp)",
+    showBackground = true,
+    widthDp = 320
+)
+@Composable
+private fun ProfileCharacterBottomSheetPreviewNarrow() {
+    FeelinTheme(darkTheme = false) {
+        ProfileCharacterBottomSheetContent(
+            onDismiss = { },
+            onSelectProfile = { },
+            selectedProfile = ProfileCharacter.PROFILE_1
         )
     }
 }

--- a/app/src/main/java/com/lyrics/feelin/core/designsystem/component/FeelinProfileCharacterBottomSheet.kt
+++ b/app/src/main/java/com/lyrics/feelin/core/designsystem/component/FeelinProfileCharacterBottomSheet.kt
@@ -8,6 +8,8 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -210,12 +212,13 @@ private fun ProfileCharacterList(
 }
 
 /**
- * 레이어 구조의 프로필 선택 아이템
+ * 레이어 구조의 프로필 선택 아이템.
  *
  * @param profile 프로필 캐릭터
  * @param isSelected 선택 상태
+ * @param isDarkMode 다크모드 여부
  * @param onClick 클릭 콜백
- * @param modifier Modifier
+ * @param modifier Modifier (보통 weight를 받음)
  */
 @Composable
 fun ProfileSelectItemLayered(
@@ -226,9 +229,7 @@ fun ProfileSelectItemLayered(
     modifier: Modifier = Modifier
 ) {
     val colors = LocalFeelinColors.current
-
     val imageRes = profile.getDrawableRes(isSelected, isDarkMode)
-
     val outerCircleColor = if (isSelected) {
         colors.brandPrimary
     } else {
@@ -237,33 +238,24 @@ fun ProfileSelectItemLayered(
 
     Box(
         modifier = modifier
-            .size(84.dp)
-            .clickable { onClick() },
+            .aspectRatio(1f)
+            .clip(CircleShape)
+            .clickable { onClick() }
+            .border(width = 2.dp, color = outerCircleColor, shape = CircleShape)
+            .padding(4.dp),
         contentAlignment = Alignment.Center
     ) {
-        Box(
+        Image(
+            painter = painterResource(id = imageRes),
+            contentDescription = "프로필 ${profile.id}",
             modifier = Modifier
-                .size(80.dp)
-                .border(width = 2.dp, outerCircleColor, CircleShape),
+                .fillMaxSize()
+                .clip(CircleShape),
+            contentScale = ContentScale.Crop
         )
-
-        Box(
-            modifier = Modifier
-                .size(72.dp)
-                .padding(2.dp),
-            contentAlignment = Alignment.Center
-        ) {
-            Image(
-                painter = painterResource(id = imageRes),
-                contentDescription = "프로필 ${profile.id}",
-                modifier = Modifier
-                    .size(72.dp)
-                    .clip(CircleShape),
-                contentScale = ContentScale.Crop
-            )
-        }
     }
 }
+
 
 @Composable
 private fun ProfileSelectButton(
@@ -350,7 +342,6 @@ private fun ProfileCharacterBottomSheetPreviewProfile3() {
     }
 }
 
-// 좁은 화면에서 레이아웃 확인용 Preview
 @Preview(
     name = "Narrow Screen (320dp)",
     showBackground = true,

--- a/app/src/main/java/com/lyrics/feelin/core/designsystem/component/FeelinProfileCharacterBottomSheet.kt
+++ b/app/src/main/java/com/lyrics/feelin/core/designsystem/component/FeelinProfileCharacterBottomSheet.kt
@@ -1,8 +1,11 @@
 package com.lyrics.feelin.core.designsystem.component
 
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -230,18 +233,25 @@ fun ProfileSelectItemLayered(
 ) {
     val colors = LocalFeelinColors.current
     val imageRes = profile.getDrawableRes(isSelected, isDarkMode)
+    val interactionSource = remember { MutableInteractionSource() }
+    val isPressed by interactionSource.collectIsPressedAsState()
     val outerCircleColor = if (isSelected) {
         colors.brandPrimary
     } else {
         colors.systemDisable
     }
+    val pressedBackgroundColor = if (isPressed) colors.systemPressedGreyScale else Color.Transparent
 
     Box(
         modifier = modifier
             .aspectRatio(1f)
             .clip(CircleShape)
-            .clickable { onClick() }
+            .background(color = pressedBackgroundColor, shape = CircleShape)
             .border(width = 2.dp, color = outerCircleColor, shape = CircleShape)
+            .clickable(
+                interactionSource = interactionSource,
+                indication = null
+            ) { onClick() }
             .padding(4.dp),
         contentAlignment = Alignment.Center
     ) {
@@ -255,7 +265,6 @@ fun ProfileSelectItemLayered(
         )
     }
 }
-
 
 @Composable
 private fun ProfileSelectButton(


### PR DESCRIPTION
## Please check if the PR fulfills these requirements
- [x] The commit message follows our guidelines

## What kind of change does this PR introduce?
- Bug fix

## What is the current behavior?
The profile character selection items in `ProfileCharacterBottomSheet` 
use a fixed size (84.dp), which causes layout issues on narrow screens.
Items appear too small inside their circle bounds and don't distribute 
evenly across different device widths.

Also, `@Preview` does not render because `ModalBottomSheet` is not 
supported in the Compose Preview environment.

## What is the new behavior (if this is a feature change)?
- Replaced fixed `.size(84.dp)` with `.aspectRatio(1f)` so items 
  properly use the width given by `weight(1f)` and stay square 
  on any screen size.
- Simplified the nested Box structure into a single Box with border 
  and padding.
- Extracted bottom sheet content into `ProfileCharacterBottomSheetContent` 
  so previews render correctly without `ModalBottomSheet`.
- Added a narrow screen preview (320dp) to verify the layout.

## Does this PR introduce a breaking change?
No.

## ScreenShots (If needed)
<p>
  <img src="https://github.com/user-attachments/assets/439641b5-2a4e-44ea-9a25-653b433b05d2", width="300" />
  <img src="https://github.com/user-attachments/assets/67113bb4-2781-48a7-bcb5-23835fa15392", width="300" />
</p>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized profile character bottom sheet internal UI structure and layout components
  * Updated profile selection item sizing with new responsive layout approach
  * Refactored selection item interaction state handling and behavior
* **Style**
  * Updated profile selection item visual appearance with circular layout design
  * Enhanced visual feedback for press-state interactions on profile selection items

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/project-lyrics/app-Android/pull/47)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->