### PR TITLE
SCRUM-276 feature: Add global loading overlay in FeelinNavHost

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -222,6 +222,44 @@ fabric.properties
 
 # End of https://www.toptal.com/developers/gitignore/api/android,androidstudio,gradle,kotlin,java
 
+# Created by https://www.toptal.com/developers/gitignore/api/macos
+# Edit at https://www.toptal.com/developers/gitignore?templates=macos
+
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### macOS Patch ###
+# iCloud generated files
+*.icloud
+
+# End of https://www.toptal.com/developers/gitignore/api/macos
+
 # 개인 프롬프트 파일
 .daegeun
 .daegeun/**
@@ -229,3 +267,7 @@ fabric.properties
 # oh-my-openagent files
 .sisyphus
 .sisyphus/**
+
+# antigravity cli files
+.antigravitycli
+.antigravitycli/**

--- a/app/src/main/java/com/lyrics/feelin/navigation/FeelinNavHost.kt
+++ b/app/src/main/java/com/lyrics/feelin/navigation/FeelinNavHost.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.calculateEndPadding
+import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
@@ -440,7 +441,7 @@ private fun MainScaffold(
                     .fillMaxSize()
                     .padding(
                         top = paddingValues.calculateTopPadding(),
-                        start = paddingValues.calculateEndPadding(LayoutDirection.Ltr),
+                        start = paddingValues.calculateStartPadding(LayoutDirection.Ltr),
                         end = paddingValues.calculateEndPadding(LayoutDirection.Ltr),
                         bottom = bottomPadding
                     )

--- a/app/src/main/java/com/lyrics/feelin/navigation/FeelinNavHost.kt
+++ b/app/src/main/java/com/lyrics/feelin/navigation/FeelinNavHost.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -459,7 +460,9 @@ private fun MainScaffold(
                 modifier = Modifier
                     .fillMaxSize()
                     .background(feelinColors.dim)
-                    .clearAndSetSemantics { }
+                    .clearAndSetSemantics {
+                        stateDescription = "로딩 중입니다"
+                    }
                     .pointerInput(Unit) {
                         awaitPointerEventScope {
                             while (true) {

--- a/app/src/main/java/com/lyrics/feelin/navigation/FeelinNavHost.kt
+++ b/app/src/main/java/com/lyrics/feelin/navigation/FeelinNavHost.kt
@@ -1,6 +1,8 @@
 package com.lyrics.feelin.navigation
 
 import android.util.Log
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
@@ -9,6 +11,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -17,8 +20,12 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -38,6 +45,7 @@ import com.lyrics.feelin.core.designsystem.icon.MyPageActiveIcon
 import com.lyrics.feelin.core.designsystem.icon.MyPageInactiveIcon
 import com.lyrics.feelin.core.designsystem.icon.NoteSearchingActiveIcon
 import com.lyrics.feelin.core.designsystem.icon.NoteSearchingInactiveIcon
+import com.lyrics.feelin.presentation.designsystem.theme.LocalFeelinColors
 import com.lyrics.feelin.presentation.util.openExternalBrowser
 import com.lyrics.feelin.presentation.view.community.CommunityMainScreen
 import com.lyrics.feelin.presentation.view.login.LoginScreen
@@ -318,7 +326,11 @@ private fun NavGraphBuilder.myPageNavGraph(navController: NavHostController) {
                 }
             }
 
-            MainScaffold(navController = navController, selectedIndex = 2) {
+            MainScaffold(
+                navController = navController,
+                selectedIndex = 2,
+                isBlockingLoading = logoutStatus == MyPageLogoutStatus.LOADING
+            ) {
                 SettingScreen(
                     onBackClick = { navController.popBackStack() },
                     onUserInfoClick = { navController.navigate(FeelinDestination.UserInfo.route) },
@@ -329,7 +341,6 @@ private fun NavGraphBuilder.myPageNavGraph(navController: NavHostController) {
                     onExternalBrowserClick = { url ->
                         context.openExternalBrowser(url)
                     },
-                    isLogoutLoading = logoutStatus == MyPageLogoutStatus.LOADING,
                 )
             }
         }
@@ -367,6 +378,7 @@ private fun NavGraphBuilder.internalWebViewScreen(navController: NavHostControll
 private fun MainScaffold(
     navController: NavHostController,
     selectedIndex: Int,
+    isBlockingLoading: Boolean = false,
     content: @Composable () -> Unit
 ) {
     var selectedBottomBarIndex by remember { mutableIntStateOf(selectedIndex) }
@@ -388,51 +400,79 @@ private fun MainScaffold(
         )
     }
 
-    Scaffold(
-        modifier = Modifier.fillMaxSize(),
-        bottomBar = {
-            FeelinBottomNavigation(
-                modifier = Modifier.windowInsetsPadding(WindowInsets.navigationBars),
-                items = bottomBarItems,
-                selectedIndex = selectedBottomBarIndex,
-                onItemSelect = { index ->
-                    selectedBottomBarIndex = index
-                    val destination = when (index) {
-                        0 -> FeelinDestination.HomeGraph.route
-                        1 -> FeelinDestination.NoteSearchGraph.route
-                        2 -> FeelinDestination.MyPageGraph.route
-                        else -> FeelinDestination.HomeGraph.route
-                    }
-                    navController.navigate(destination) {
-                        popUpTo(FeelinDestination.MainGraph.route) {
-                            saveState = true
+    Box(modifier = Modifier.fillMaxSize()) {
+        Scaffold(
+            modifier = Modifier.fillMaxSize(),
+            bottomBar = {
+                FeelinBottomNavigation(
+                    modifier = Modifier.windowInsetsPadding(WindowInsets.navigationBars),
+                    items = bottomBarItems,
+                    selectedIndex = selectedBottomBarIndex,
+                    onItemSelect = { index ->
+                        selectedBottomBarIndex = index
+                        val destination = when (index) {
+                            0 -> FeelinDestination.HomeGraph.route
+                            1 -> FeelinDestination.NoteSearchGraph.route
+                            2 -> FeelinDestination.MyPageGraph.route
+                            else -> FeelinDestination.HomeGraph.route
                         }
-                        launchSingleTop = true
-                        restoreState = true
-                    }
-                },
-            )
-        },
-        contentWindowInsets = WindowInsets(0)
-    ) { paddingValues ->
-        // WindowInsets.navigationBars가 30dp 이하인 경우 Scaffold paddingValues 사용
-        var bottomPadding = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
-        if (bottomPadding <= 30.dp) {
-            bottomPadding = paddingValues.calculateBottomPadding()
-        }
-        Log.d("FeelinNavHost", "MainScaffold: bottomPadding=$bottomPadding")
-
-        Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(
-                    top = paddingValues.calculateTopPadding(),
-                    start = paddingValues.calculateEndPadding(LayoutDirection.Ltr),
-                    end = paddingValues.calculateEndPadding(LayoutDirection.Ltr),
-                    bottom = bottomPadding
+                        navController.navigate(destination) {
+                            popUpTo(FeelinDestination.MainGraph.route) {
+                                saveState = true
+                            }
+                            launchSingleTop = true
+                            restoreState = true
+                        }
+                    },
                 )
-        ) {
-            content()
+            },
+            contentWindowInsets = WindowInsets(0)
+        ) { paddingValues ->
+            // WindowInsets.navigationBars가 30dp 이하인 경우 Scaffold paddingValues 사용
+            var bottomPadding = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
+            if (bottomPadding <= 30.dp) {
+                bottomPadding = paddingValues.calculateBottomPadding()
+            }
+            Log.d("FeelinNavHost", "MainScaffold: bottomPadding=$bottomPadding")
+
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(
+                        top = paddingValues.calculateTopPadding(),
+                        start = paddingValues.calculateEndPadding(LayoutDirection.Ltr),
+                        end = paddingValues.calculateEndPadding(LayoutDirection.Ltr),
+                        bottom = bottomPadding
+                    )
+            ) {
+                content()
+            }
+        }
+
+        BackHandler(enabled = isBlockingLoading) { }
+
+        if (isBlockingLoading) {
+            val feelinColors = LocalFeelinColors.current
+
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(feelinColors.dim)
+                    .clearAndSetSemantics { }
+                    .pointerInput(Unit) {
+                        awaitPointerEventScope {
+                            while (true) {
+                                val event = awaitPointerEvent(PointerEventPass.Initial)
+                                event.changes.forEach { pointerInputChange ->
+                                    pointerInputChange.consume()
+                                }
+                            }
+                        }
+                    },
+                contentAlignment = Alignment.Center,
+            ) {
+                CircularProgressIndicator()
+            }
         }
     }
 }

--- a/app/src/main/java/com/lyrics/feelin/presentation/view/mypage/setting/SettingScreen.kt
+++ b/app/src/main/java/com/lyrics/feelin/presentation/view/mypage/setting/SettingScreen.kt
@@ -14,7 +14,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.windowInsetsPadding
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
@@ -24,10 +23,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.input.pointer.PointerEventPass
-import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.lyrics.feelin.R
@@ -46,7 +42,6 @@ fun SettingScreen(
     onInternalWebViewClick: (String) -> Unit,
     onExternalBrowserClick: (String) -> Unit,
     modifier: Modifier = Modifier,
-    isLogoutLoading: Boolean = false,
 ) {
     val feelinColors = LocalFeelinColors.current
     var isLogoutDialogVisible by rememberSaveable { mutableStateOf(false) }
@@ -131,38 +126,6 @@ fun SettingScreen(
                 Spacer(modifier = Modifier.height(22.dp))
             }
         }
-
-        if (isLogoutLoading) {
-            // FIXME(@이대근): 화면 전역으로 오버레이가 적용되지 않아 하단바를 선택할 수 있음 2026.05.17.
-            LogoutLoadingOverlay()
-        }
-    }
-}
-
-@Composable
-private fun LogoutLoadingOverlay(
-    modifier: Modifier = Modifier,
-) {
-    val feelinColors = LocalFeelinColors.current
-
-    Box(
-        modifier = modifier
-            .fillMaxSize()
-            .background(feelinColors.dim)
-            .clearAndSetSemantics { }
-            .pointerInput(Unit) {
-                awaitPointerEventScope {
-                    while (true) {
-                        val event = awaitPointerEvent(PointerEventPass.Initial)
-                        event.changes.forEach { pointerInputChange ->
-                            pointerInputChange.consume()
-                        }
-                    }
-                }
-            },
-        contentAlignment = Alignment.Center,
-    ) {
-        CircularProgressIndicator()
     }
 }
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] The commit message follows our guidelines

## What kind of change does this PR introduce?
- Add feature

# What is the current behavior?
로그아웃 로딩 오버레이가 `SettingScreen` 내부 content 영역에만 표시되어 하단 탭과 시스템 뒤로가기로 화면을 이탈할 수 있습니다.

# What is the new behavior (if this is a feature change)?
`MainScaffold`에 `isBlockingLoading`을 추가해 로그아웃 로딩 중 main content와 bottom navigation 위에 동일한 dim + progress overlay를 표시합니다. 로딩 중 시스템 back 이벤트도 소비합니다.

## Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No.

## ScreenShots (If needed)

### User

로딩 오버레이가 표시되게 플로우를 녹화해 첨부했습니다. 5~6초경 전역 오버레이가 표시됩니다.

https://github.com/user-attachments/assets/64b1dcd5-23a7-4814-aaf3-551922962007


## Other information:
Verification:
- `cmd.exe /c gradlew.bat detekt`
- `cmd.exe /c gradlew.bat :app:assembleDebug`
- `cmd.exe /c gradlew.bat testDebugUnitTest`
- `git diff --check`

Manual device QA was not run because no Android device/emulator was attached in the local environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced the logout experience with a full-screen blocking loading overlay that prevents user interaction and displays visual feedback while logout is in progress.

* **Chores**
  * Updated project configuration to include macOS-specific ignore patterns.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/project-lyrics/app-Android/pull/50?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->