### PR TITLE
fix: Refactor login error handling

### DIFF
--- a/app/src/main/java/com/lyrics/feelin/presentation/view/login/LoginScreen.kt
+++ b/app/src/main/java/com/lyrics/feelin/presentation/view/login/LoginScreen.kt
@@ -91,7 +91,7 @@ fun LoginScreen(
                     isDismissButtonEnable = false,
                 )
             }
-            is LoginError.OAuthError -> {
+            is LoginError.NonBackendError -> {
                 FeelinModalDialog(
                     title = "로그인 시도중 오류가 발생했어요.",
                     description = "에러코드 [-1]",

--- a/app/src/main/java/com/lyrics/feelin/presentation/view/login/LoginScreen.kt
+++ b/app/src/main/java/com/lyrics/feelin/presentation/view/login/LoginScreen.kt
@@ -78,30 +78,30 @@ fun LoginScreen(
     }
 
     if (loginUiState is LoginUiState.Error) {
-        if ((loginUiState as LoginUiState.Error).error.type == LoginErrorType.BACKEND_SERVER) {
-            val title = (loginUiState as LoginUiState.Error).error.description
-                ?: "로그인 시도중 오류가 발생했어요."
-            val code = (loginUiState as LoginUiState.Error).error.code
-            // MARK(@이대근): 추후 통합된 서버 에러 다이얼로그로 변경 2026.03.15.
-            FeelinModalDialog(
-                title = title,
-                description = "에러코드 [$code]",
-                confirmButtonText = "확인",
-                onConfirmButtonClick = {
-                    loginViewModel.clearLoginUiState()
-                },
-                isDismissButtonEnable = false,
-            )
-        } else {
-            FeelinModalDialog(
-                title = "로그인 시도중 오류가 발생했어요.",
-                description = "에러코드 [-1]",
-                confirmButtonText = "확인",
-                onConfirmButtonClick = {
-                    loginViewModel.clearLoginUiState()
-                },
-                isDismissButtonEnable = false,
-            )
+        when (val error = (loginUiState as LoginUiState.Error).error) {
+            is LoginError.BackendError -> {
+                // MARK(@이대근): 추후 통합된 서버 에러 다이얼로그로 변경 2026.03.15.
+                FeelinModalDialog(
+                    title = error.description,
+                    description = "에러코드 [${error.code}]",
+                    confirmButtonText = "확인",
+                    onConfirmButtonClick = {
+                        loginViewModel.clearLoginUiState()
+                    },
+                    isDismissButtonEnable = false,
+                )
+            }
+            is LoginError.OAuthError -> {
+                FeelinModalDialog(
+                    title = "로그인 시도중 오류가 발생했어요.",
+                    description = "에러코드 [-1]",
+                    confirmButtonText = "확인",
+                    onConfirmButtonClick = {
+                        loginViewModel.clearLoginUiState()
+                    },
+                    isDismissButtonEnable = false,
+                )
+            }
         }
     }
 

--- a/app/src/main/java/com/lyrics/feelin/presentation/view/login/LoginViewModel.kt
+++ b/app/src/main/java/com/lyrics/feelin/presentation/view/login/LoginViewModel.kt
@@ -30,7 +30,7 @@ sealed class LoginError {
         val code: String?,
     ) : LoginError()
 
-    data class OAuthError(
+    data class NonBackendError(
         val type: LoginErrorType,
         val code: String? = null,
     ) : LoginError()
@@ -95,7 +95,7 @@ class LoginViewModel @Inject constructor(
                     code = code,
                 )
             } else {
-                LoginError.OAuthError(
+                LoginError.NonBackendError(
                     type = type,
                     code = code,
                 )

--- a/app/src/main/java/com/lyrics/feelin/presentation/view/login/LoginViewModel.kt
+++ b/app/src/main/java/com/lyrics/feelin/presentation/view/login/LoginViewModel.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 
 private const val TAG = "LoginViewModel"
+private const val DEFAULT_LOGIN_ERROR_DESCRIPTION = "로그인 시도중 오류가 발생했어요."
 
 enum class LoginErrorType {
     OAUTH_CLIENT,
@@ -23,13 +24,17 @@ enum class LoginErrorType {
     UNKNOWN,
 }
 
-data class LoginError(
-    val type: LoginErrorType,
-    /** 에러 설명, 자체 서버에서 받는 에러에만 존재 */
-    val description: String? = null,
-    /** 에러 코드, 자체 서버에서 받는 에러에만 존재 */
-    val code: String? = null,
-)
+sealed class LoginError {
+    data class BackendError(
+        val description: String,
+        val code: String?,
+    ) : LoginError()
+
+    data class OAuthError(
+        val type: LoginErrorType,
+        val code: String? = null,
+    ) : LoginError()
+}
 
 sealed interface LoginUiState {
     data object Idle : LoginUiState
@@ -84,11 +89,17 @@ class LoginViewModel @Inject constructor(
 
     fun updateLoginError(type: LoginErrorType, message: String? = null, code: String? = null) {
         _loginUiState.value = LoginUiState.Error(
-            error = LoginError(
-                type = type,
-                description = message,
-                code = code,
-            )
+            error = if (type == LoginErrorType.BACKEND_SERVER) {
+                LoginError.BackendError(
+                    description = message ?: DEFAULT_LOGIN_ERROR_DESCRIPTION,
+                    code = code,
+                )
+            } else {
+                LoginError.OAuthError(
+                    type = type,
+                    code = code,
+                )
+            }
         )
     }
 

--- a/app/src/test/java/com/lyrics/feelin/presentation/view/login/LoginErrorTest.kt
+++ b/app/src/test/java/com/lyrics/feelin/presentation/view/login/LoginErrorTest.kt
@@ -1,0 +1,31 @@
+package com.lyrics.feelin.presentation.view.login
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class LoginErrorTest {
+    @Test
+    fun backendErrorRequiresDescriptionAndKeepsCode() {
+        val error: LoginError = LoginError.BackendError(
+            description = "서버 오류",
+            code = "05000",
+        )
+
+        assertTrue(error is LoginError.BackendError)
+        assertEquals("서버 오류", (error as LoginError.BackendError).description)
+        assertEquals("05000", error.code)
+    }
+
+    @Test
+    fun oauthErrorKeepsOAuthFailureTypeAndCode() {
+        val error: LoginError = LoginError.OAuthError(
+            type = LoginErrorType.OAUTH_CLIENT,
+            code = "Cancelled",
+        )
+
+        assertTrue(error is LoginError.OAuthError)
+        assertEquals(LoginErrorType.OAUTH_CLIENT, (error as LoginError.OAuthError).type)
+        assertEquals("Cancelled", error.code)
+    }
+}

--- a/app/src/test/java/com/lyrics/feelin/presentation/view/login/LoginErrorTest.kt
+++ b/app/src/test/java/com/lyrics/feelin/presentation/view/login/LoginErrorTest.kt
@@ -18,14 +18,14 @@ class LoginErrorTest {
     }
 
     @Test
-    fun oauthErrorKeepsOAuthFailureTypeAndCode() {
-        val error: LoginError = LoginError.OAuthError(
+    fun nonBackendErrorKeepsFailureTypeAndCode() {
+        val error: LoginError = LoginError.NonBackendError(
             type = LoginErrorType.OAUTH_CLIENT,
             code = "Cancelled",
         )
 
-        assertTrue(error is LoginError.OAuthError)
-        assertEquals(LoginErrorType.OAUTH_CLIENT, (error as LoginError.OAuthError).type)
+        assertTrue(error is LoginError.NonBackendError)
+        assertEquals(LoginErrorType.OAUTH_CLIENT, (error as LoginError.NonBackendError).type)
         assertEquals("Cancelled", error.code)
     }
 }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] The commit message follows our guidelines

## What kind of change does this PR introduce?
- Bug fix
- Refactoring

# What is the current behavior?
로그인 에러가 단일 `LoginError` data class로 표현되어 백엔드 서버 에러와 비백엔드 에러가 타입 수준에서 분리되지 않았습니다. 이로 인해 UI에서 `LoginErrorType`과 nullable 필드를 직접 확인해야 했습니다.

# What is the new behavior (if this is a feature change)?
`LoginError`를 sealed class로 변경해 에러 유형을 타입 안전하게 분리했습니다.

백엔드 서버 에러는 `BackendError`로 표현하며, 서버 에러 설명이 없을 때 기본 문구를 사용합니다. 비백엔드 에러는 `NonBackendError`로 표현해 기존 `LoginErrorType`과 선택적 코드를 유지합니다.

`LoginScreen`은 `when` 분기로 에러 variant를 직접 처리하도록 변경했고, `LoginErrorTest`를 추가해 두 에러 variant의 값을 검증합니다.

## Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
내부 로그인 에러 모델이 data class에서 sealed class로 변경되었습니다. 앱 내부의 관련 사용처는 함께 수정되었습니다.

## ScreenShots (If needed)
해당 없음

## Other information:
Related to issue #35

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error message handling in the login flow with more reliable default messaging for certain error scenarios.

* **Tests**
  * Added test coverage for login error classification to ensure proper error type handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->