### PR TITLE
ci: Update android-actions/setup-android to v4

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -71,7 +71,7 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
 
       - name: Set up Android SDK
-        uses: android-actions/setup-android@v3
+        uses: android-actions/setup-android@v4
 
       - name: Grant execute permission for gradlew
         run: chmod +x ./gradlew


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] The commit message follows our guidelines


## What kind of change does this PR introduce?
- CI/CD update


# What is the current behavior?
`.github/workflows/android-ci.yml` uses `android-actions/setup-android@v3`, which triggers the following Node.js 20 deprecation warning in GitHub Actions:

> Node.js 20 actions are deprecated... The following actions are running on Node.js 20... `android-actions/setup-android@v3`

See: https://github.blog/changelog/2025-09-19/deprecation-of-node-20-on-github-actions-runners/


# What is the new behavior (if this is a feature change)?
Bumps `android-actions/setup-android` from `v3` to `v4`.  
`v4` is the latest release of the action and runs on Node.js 24, removing the deprecation warning and keeping the workflow aligned with GitHub's runner roadmap.



## Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No. The action input interface is unchanged between v3 and v4, so no workflow or application changes are required.



## ScreenShots (If needed)
Not applicable — CI workflow change only.



## Other information:
- Branch naming: `ci/update-android-actions-v4` was chosen because this change has no associated Jira ticket and only touches CI configuration. The `ci/` prefix follows the common convention for workflow/infrastructure-only changes, and the descriptive suffix indicates the exact dependency being updated.
- Related changelog: https://github.blog/changelog/2025-09-19/deprecation-of-node-20-on-github-actions-runners/
- Action release page: https://github.com/android-actions/setup-android/releases/tag/v4.0.1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Android build infrastructure to use the latest version of Android SDK setup tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->