### PR TITLE
SCRUM-259 design: add home layout

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -177,6 +177,7 @@ dependencies {
     implementation(libs.androidx.webkit)
 
     testImplementation(libs.junit)
+    testImplementation(libs.kotlinx.coroutines.test)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
     androidTestImplementation(platform(libs.androidx.compose.bom))

--- a/app/src/main/java/com/lyrics/feelin/core/designsystem/component/FeelinTopAppBar.kt
+++ b/app/src/main/java/com/lyrics/feelin/core/designsystem/component/FeelinTopAppBar.kt
@@ -33,7 +33,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.lyrics.feelin.core.designsystem.icon.BackIcon
 import com.lyrics.feelin.core.designsystem.icon.CloseIcon
-import com.lyrics.feelin.core.designsystem.icon.NotificationIcon
+import com.lyrics.feelin.core.designsystem.icon.NotificationIconLight
 import com.lyrics.feelin.core.designsystem.icon.SettingsIconDark
 import com.lyrics.feelin.core.designsystem.icon.SettingsIconLight
 import com.lyrics.feelin.presentation.designsystem.theme.FeelinTheme
@@ -313,7 +313,7 @@ private fun FeelinTransparentTopAppBarPreview() {
                 onBackClick = {},
                 actions = {
                     TopBarIconButton(
-                        imageVector = NotificationIcon,
+                        imageVector = NotificationIconLight,
                         contentDescription = "알림",
                         onClick = {}
                     )
@@ -364,7 +364,7 @@ private fun FeelinTopAppBarDoubleIconPreview() {
                         onClick = {}
                     )
                     TopBarIconButton(
-                        imageVector = NotificationIcon,
+                        imageVector = NotificationIconLight,
                         contentDescription = "알림",
                         tint = LocalFeelinColors.current.gray09,
                         onClick = {}

--- a/app/src/main/java/com/lyrics/feelin/core/designsystem/icon/Icons.kt
+++ b/app/src/main/java/com/lyrics/feelin/core/designsystem/icon/Icons.kt
@@ -33,13 +33,21 @@ val BackIcon: ImageVector
     @Composable
     get() = ImageVector.vectorResource(id = R.drawable.ic_back)
 
-val NotificationIcon: ImageVector
+val NotificationIconLight: ImageVector
     @Composable
-    get() = ImageVector.vectorResource(id = R.drawable.ic_notification)
+    get() = ImageVector.vectorResource(id = R.drawable.notification_light_badge_off)
 
-val NotificationWithBadgeIcon: ImageVector
+val NotificationWithBadgeIconLight: ImageVector
     @Composable
     get() = ImageVector.vectorResource(id = R.drawable.notification_light_badge_on)
+
+val NotificationIconDark: ImageVector
+    @Composable
+    get() = ImageVector.vectorResource(id = R.drawable.notification_dark_badge_off)
+
+val NotificationWithBadgeIconDark: ImageVector
+    @Composable
+    get() = ImageVector.vectorResource(id = R.drawable.notification_dark_badge_on)
 
 val FeelinTextIcon: ImageVector
     @Composable

--- a/app/src/main/java/com/lyrics/feelin/core/designsystem/icon/Icons.kt
+++ b/app/src/main/java/com/lyrics/feelin/core/designsystem/icon/Icons.kt
@@ -37,6 +37,10 @@ val NotificationIcon: ImageVector
     @Composable
     get() = ImageVector.vectorResource(id = R.drawable.ic_notification)
 
+val NotificationWithBadgeIcon: ImageVector
+    @Composable
+    get() = ImageVector.vectorResource(id = R.drawable.notification_light_badge_on)
+
 val FeelinTextIcon: ImageVector
     @Composable
     get() = ImageVector.vectorResource(id = R.drawable.feelin_text_logo)

--- a/app/src/main/java/com/lyrics/feelin/navigation/FeelinDestination.kt
+++ b/app/src/main/java/com/lyrics/feelin/navigation/FeelinDestination.kt
@@ -38,6 +38,13 @@ sealed class FeelinDestination(
 
     // Main Flow (with Bottom Navigation)
     object Home : FeelinDestination(route = "home")
+    object ArtistRecord : FeelinDestination(route = "artist_record/{$ARTIST_ID_ARGUMENT}") {
+        const val ArtistIdArgument = ARTIST_ID_ARGUMENT
+
+        fun createRoute(artistId: Long): String {
+            return "artist_record/$artistId"
+        }
+    }
     object NoteSearch : FeelinDestination(route = "note_search")
     object NoteSearchResult : FeelinDestination(route = "note_search_result")
     object NoteFormCreate : FeelinDestination(route = "note_form/create")

--- a/app/src/main/java/com/lyrics/feelin/navigation/FeelinNavHost.kt
+++ b/app/src/main/java/com/lyrics/feelin/navigation/FeelinNavHost.kt
@@ -267,9 +267,27 @@ private fun NavGraphBuilder.mainNavGraph(navController: NavHostController) {
         navigation(startDestination = FeelinDestination.Home.route, route = FeelinDestination.HomeGraph.route) {
             composable(FeelinDestination.Home.route) {
                 MainScaffold(navController = navController, selectedIndex = 0) {
+                    HomeRoute(navController = navController)
+                }
+            }
+
+            composable(
+                route = FeelinDestination.ArtistRecord.route,
+                arguments = listOf(
+                    navArgument(FeelinDestination.ArtistRecord.ArtistIdArgument) {
+                        type = NavType.LongType
+                    }
+                )
+            ) { backStackEntry ->
+                val arguments = backStackEntry.arguments
+                val artistId = arguments?.getLong(
+                    FeelinDestination.ArtistRecord.ArtistIdArgument
+                ) ?: return@composable
+
+                MainScaffold(navController = navController, selectedIndex = 0) {
                     CommunityMainScreen(
-                        artistName = "필릭스",
-                        onBack = {},
+                        artistName = "아티스트 $artistId",
+                        onBack = { navController.popBackStack() },
                         onNoteClick = { noteId ->
                             navController.navigate(FeelinDestination.NoteDetail.createRoute(noteId))
                         },

--- a/app/src/main/java/com/lyrics/feelin/navigation/HomeNavigation.kt
+++ b/app/src/main/java/com/lyrics/feelin/navigation/HomeNavigation.kt
@@ -1,0 +1,31 @@
+package com.lyrics.feelin.navigation
+
+import android.util.Log
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.navigation.NavController
+import com.lyrics.feelin.presentation.view.home.HomeScreen
+
+@Composable
+fun HomeRoute(
+    navController: NavController,
+    modifier: Modifier = Modifier
+) {
+    HomeScreen(
+        modifier = modifier,
+        onBannerClick = { linkUrl ->
+            // FIXME(@이대근): 외부 브라우저로 표시 필요 2026.06.17.
+            navController.navigate(FeelinDestination.InternalWebView.createRoute(linkUrl))
+        },
+        onArtistClick = { artistId ->
+            navController.navigate(FeelinDestination.ArtistRecord.createRoute(artistId))
+        },
+        onNoteClick = { noteId ->
+            navController.navigate(FeelinDestination.NoteDetail.createRoute(noteId))
+        },
+        onNotificationClick = {
+            // TODO(@이대근): 추후 알림 화면 라우트 연결 2026.06.17.
+            Log.d("HomeRoute", "Notification clicked")
+        }
+    )
+}

--- a/app/src/main/java/com/lyrics/feelin/presentation/view/community/CommunityMainScreen.kt
+++ b/app/src/main/java/com/lyrics/feelin/presentation/view/community/CommunityMainScreen.kt
@@ -56,7 +56,7 @@ import com.lyrics.feelin.R
 import com.lyrics.feelin.core.designsystem.component.FeelinTopAppBarWithBack
 import com.lyrics.feelin.core.designsystem.component.FeelinTransparentTopAppBar
 import com.lyrics.feelin.core.designsystem.component.TopBarIconButton
-import com.lyrics.feelin.core.designsystem.icon.NotificationIcon
+import com.lyrics.feelin.core.designsystem.icon.NotificationIconLight
 import com.lyrics.feelin.presentation.designsystem.theme.FeelinTheme
 import com.lyrics.feelin.presentation.designsystem.theme.FeelinTypography
 import com.lyrics.feelin.presentation.designsystem.theme.LightGray00
@@ -112,7 +112,7 @@ fun CommunityMainScreen(
                     onBackClick = onBack,
                     actions = {
                         TopBarIconButton(
-                            imageVector = NotificationIcon,
+                            imageVector = NotificationIconLight,
                             contentDescription = "알림",
                             tint = LightGray09, // 투명 상태일 때는 다크모드 미 적용입니다.
                             onClick = {},

--- a/app/src/main/java/com/lyrics/feelin/presentation/view/component/artist/ArtistBubbleComponentData.kt
+++ b/app/src/main/java/com/lyrics/feelin/presentation/view/component/artist/ArtistBubbleComponentData.kt
@@ -16,6 +16,7 @@ sealed interface ArtistBubbleComponentData {
     data class HomeFavoriteArtistType(
         override val name: String,
         val imageUrl: String,
+        val id: Long? = null,
     ) : ArtistBubbleComponentData
 
     /** 홈 화면 아티스트 선택 버튼*/

--- a/app/src/main/java/com/lyrics/feelin/presentation/view/component/artist/ArtistProfileComponent.kt
+++ b/app/src/main/java/com/lyrics/feelin/presentation/view/component/artist/ArtistProfileComponent.kt
@@ -2,6 +2,7 @@ package com.lyrics.feelin.presentation.view.component.artist
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -33,7 +34,11 @@ import com.lyrics.feelin.presentation.designsystem.theme.LightSystemDisable
 import com.lyrics.feelin.presentation.designsystem.theme.LocalFeelinColors
 
 @Composable
-fun ArtistBubbleComponent(state: ArtistBubbleComponentData, modifier: Modifier = Modifier) {
+fun ArtistBubbleComponent(
+    state: ArtistBubbleComponentData,
+    modifier: Modifier = Modifier,
+    onClick: (() -> Unit)? = null,
+) {
     val feelinColors = LocalFeelinColors.current
 
     val imgSize = when (state) {
@@ -63,8 +68,14 @@ fun ArtistBubbleComponent(state: ArtistBubbleComponentData, modifier: Modifier =
         color = if (state is ArtistBubbleComponentData.InitialSelectArtistType) LightGray08 else feelinColors.gray08
     )
 
+    val bubbleModifier = if (onClick != null) {
+        modifier.clickable(onClick = onClick)
+    } else {
+        modifier
+    }
+
     ArtistProfileLayout(
-        modifier = modifier,
+        modifier = bubbleModifier,
         mainContent = {
             if (state is ArtistBubbleComponentData.HomeFavoriteSearchType) {
                 Box(

--- a/app/src/main/java/com/lyrics/feelin/presentation/view/component/note/NoteComponent.kt
+++ b/app/src/main/java/com/lyrics/feelin/presentation/view/component/note/NoteComponent.kt
@@ -44,6 +44,8 @@ fun NoteComponent(
     noteData: NoteComponentData,
     modifier: Modifier = Modifier,
     onClick: ((NoteComponentData) -> Unit)? = null,
+    onLikeClick: ((NoteComponentData) -> Unit)? = null,
+    onBookmarkClick: ((NoteComponentData) -> Unit)? = null,
 ) {
     val feelinColors = LocalFeelinColors.current
 
@@ -132,7 +134,16 @@ fun NoteComponent(
                         }
                     ),
                     contentDescription = "note like icon",
-                    modifier = Modifier.size(24.dp).padding(end = 4.dp),
+                    modifier = Modifier
+                        .size(24.dp)
+                        .padding(end = 4.dp)
+                        .then(
+                            if (onLikeClick != null) {
+                                Modifier.clickable { onLikeClick(noteData) }
+                            } else {
+                                Modifier
+                            }
+                        ),
                     colorFilter = ColorFilter.tint(feelinColors.gray03).takeUnless { noteData.isLiked },
                 )
                 Text(
@@ -162,7 +173,15 @@ fun NoteComponent(
                 ),
                 contentDescription =
                 "note is ${if (noteData.isBookmarked) "" else "not "}bookmarked",
-                modifier = Modifier.size(24.dp),
+                modifier = Modifier
+                    .size(24.dp)
+                    .then(
+                        if (onBookmarkClick != null) {
+                            Modifier.clickable { onBookmarkClick(noteData) }
+                        } else {
+                            Modifier
+                        }
+                    ),
                 colorFilter = ColorFilter.tint(feelinColors.gray03).takeUnless { noteData.isLiked }
             )
         }

--- a/app/src/main/java/com/lyrics/feelin/presentation/view/home/HomeScreen.kt
+++ b/app/src/main/java/com/lyrics/feelin/presentation/view/home/HomeScreen.kt
@@ -1,6 +1,7 @@
 package com.lyrics.feelin.presentation.view.home
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
@@ -24,6 +25,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -168,6 +170,7 @@ fun HomeScreen(
             Box(
                 modifier = Modifier
                     .fillMaxSize()
+                    .pointerInput(Unit) { detectTapGestures { } }
                     .background(color = feelinColors.dim),
                 contentAlignment = Alignment.Center
             ) {

--- a/app/src/main/java/com/lyrics/feelin/presentation/view/home/HomeScreen.kt
+++ b/app/src/main/java/com/lyrics/feelin/presentation/view/home/HomeScreen.kt
@@ -1,0 +1,200 @@
+package com.lyrics.feelin.presentation.view.home
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.lyrics.feelin.core.designsystem.component.FeelinModalDialog
+import com.lyrics.feelin.presentation.designsystem.theme.FeelinTheme
+import com.lyrics.feelin.presentation.designsystem.theme.LocalFeelinColors
+import com.lyrics.feelin.presentation.view.component.artist.ArtistBubbleComponentData
+import com.lyrics.feelin.presentation.view.home.component.ArtistRow
+import com.lyrics.feelin.presentation.view.home.component.BannerSection
+import com.lyrics.feelin.presentation.view.home.component.DummyBannerSection
+import com.lyrics.feelin.presentation.view.home.component.FeedSection
+import com.lyrics.feelin.presentation.view.home.component.HomeHeader
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun HomeScreen(
+    modifier: Modifier = Modifier,
+    onBannerClick: (String) -> Unit,
+    onArtistClick: (Long) -> Unit,
+    onNoteClick: (Long) -> Unit,
+    onNotificationClick: () -> Unit,
+    viewModel: HomeViewModel = hiltViewModel(),
+) {
+    val uiState by viewModel.uiState.collectAsState()
+
+    LaunchedEffect(Unit) {
+        viewModel.loadHomeData()
+    }
+
+    val feelinColors = LocalFeelinColors.current
+
+    Scaffold(
+        topBar = {
+            HomeHeader(
+                hasUnreadNotification = uiState.hasUnreadNotification,
+                onNotificationClick = onNotificationClick,
+                modifier = Modifier
+                    .padding(top = 24.dp)
+                    .padding(horizontal = 20.dp)
+            )
+        },
+        containerColor = feelinColors.backgroundPrimary,
+        modifier = Modifier
+            .windowInsetsPadding(WindowInsets.systemBars.only(WindowInsetsSides.Top))
+            .fillMaxSize()
+    ) { innerPadding ->
+        PullToRefreshBox(
+            isRefreshing = uiState.isRefreshing,
+            onRefresh = viewModel::refresh,
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+        ) {
+            LazyColumn(
+                modifier = Modifier.fillMaxSize(),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                uiState.banner?.let { banner ->
+                    item {
+                        BannerSection(
+                            banner = banner,
+                            onBannerClick = onBannerClick,
+                            modifier = Modifier
+                                .padding(vertical = 24.dp, horizontal = 20.dp)
+                        )
+                    }
+                }
+
+                // 배너가 아직 날아오지 않은 초기 로딩 상태에서 레이아웃 붕괴를 막기 위한 플레이스홀더다.
+                if (uiState.banner == null && uiState.errorMessage == null) {
+                    item {
+                        DummyBannerSection(
+                            modifier = Modifier.padding(vertical = 24.dp, horizontal = 20.dp)
+                        )
+                    }
+                }
+
+                // 풀투리프레시 등 초기 로딩이 아닌 시점의 오류는 본문 중앙에 별도 메시지를 노출한다.
+                if (uiState.errorMessage != null && !uiState.isInitialLoading) {
+                    item {
+                        Box(
+                            modifier = Modifier.fillMaxSize().padding(vertical = 40.dp),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Text(text = "데이터를 불러오는 중 오류가 발생했습니다.")
+                        }
+                    }
+                } else {
+                    if (uiState.artists.isNotEmpty()) {
+                        item {
+                            ArtistRow(
+                                artists = uiState.artists,
+                                onArtistClick = onArtistClick,
+                                onFindArtistsClick = {},
+                                onShowAllArtistsClick = {},
+                            )
+                        }
+                    }
+
+                    if (uiState.isInitialLoading) {
+                        // 관심 아티스트 행 역시 로딩 중 레이아웃 높이를 유지하기 위해 더미 아이템을 보여준다.
+                        item {
+                            ArtistRow(
+                                artists = listOf(
+                                    ArtistBubbleComponentData.HomeFavoriteSearchType(name = "찾아보기")
+                                ),
+                                onArtistClick = {},
+                                onFindArtistsClick = {},
+                                onShowAllArtistsClick = {},
+                            )
+                        }
+                    }
+
+                    item {
+                        Spacer(
+                            modifier = Modifier
+                                .padding(top = 32.dp, bottom = 24.dp)
+                                .fillMaxWidth()
+                                .height(8.dp)
+                                .background(color = feelinColors.backgroundTertiary)
+                        )
+                    }
+
+                    item {
+                        FeedSection(
+                            uiState = uiState,
+                            onTabClick = viewModel::selectTab,
+                            onFilterClick = viewModel::selectFilter,
+                            onNoteClick = onNoteClick,
+                            onNoteLikeClick = viewModel::toggleLike,
+                            onNoteBookmarkClick = viewModel::toggleBookmark
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    // 최초 진입 시 전체 화면을 덮는 오버레이로, 중복 요청과 터치 이벤트를 차단한다.
+    if (uiState.isInitialLoading) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(color = feelinColors.dim),
+            contentAlignment = Alignment.Center
+        ) {
+            CircularProgressIndicator()
+        }
+    }
+
+    if (uiState.errorMessage != null) {
+        // MARK: 실제 에러와 메시지 표현 필요
+        FeelinModalDialog(
+            title = uiState.errorMessage!!,
+            description = "에러코드 [-1]",
+            confirmButtonText = "확인",
+            onConfirmButtonClick = viewModel::clearError
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun HomeScreenPreviewLoading() {
+    FeelinTheme {
+        HomeScreen(
+            viewModel = HomeViewModel(shouldFailLoading = false),
+            onBannerClick = {},
+            onArtistClick = {},
+            onNoteClick = {},
+            onNotificationClick = {},
+        )
+    }
+}

--- a/app/src/main/java/com/lyrics/feelin/presentation/view/home/HomeScreen.kt
+++ b/app/src/main/java/com/lyrics/feelin/presentation/view/home/HomeScreen.kt
@@ -36,8 +36,8 @@ import com.lyrics.feelin.presentation.view.component.artist.ArtistBubbleComponen
 import com.lyrics.feelin.presentation.view.home.component.ArtistRow
 import com.lyrics.feelin.presentation.view.home.component.BannerSection
 import com.lyrics.feelin.presentation.view.home.component.DummyBannerSection
-import com.lyrics.feelin.presentation.view.home.component.FeedSection
 import com.lyrics.feelin.presentation.view.home.component.HomeHeader
+import com.lyrics.feelin.presentation.view.home.component.feedSection
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -150,16 +150,14 @@ fun HomeScreen(
                             )
                         }
 
-                        item {
-                            FeedSection(
-                                uiState = uiState,
-                                onTabClick = viewModel::selectTab,
-                                onFilterClick = viewModel::selectFilter,
-                                onNoteClick = onNoteClick,
-                                onNoteLikeClick = viewModel::toggleLike,
-                                onNoteBookmarkClick = viewModel::toggleBookmark
-                            )
-                        }
+                        feedSection(
+                            uiState = uiState,
+                            onTabClick = viewModel::selectTab,
+                            onFilterClick = viewModel::selectFilter,
+                            onNoteClick = onNoteClick,
+                            onNoteLikeClick = viewModel::toggleLike,
+                            onNoteBookmarkClick = viewModel::toggleBookmark
+                        )
                     }
                 }
             }

--- a/app/src/main/java/com/lyrics/feelin/presentation/view/home/HomeScreen.kt
+++ b/app/src/main/java/com/lyrics/feelin/presentation/view/home/HomeScreen.kt
@@ -40,11 +40,11 @@ import com.lyrics.feelin.presentation.view.home.component.HomeHeader
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun HomeScreen(
-    modifier: Modifier = Modifier,
     onBannerClick: (String) -> Unit,
     onArtistClick: (Long) -> Unit,
     onNoteClick: (Long) -> Unit,
     onNotificationClick: () -> Unit,
+    modifier: Modifier = Modifier,
     viewModel: HomeViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsState()
@@ -55,133 +55,135 @@ fun HomeScreen(
 
     val feelinColors = LocalFeelinColors.current
 
-    Scaffold(
-        topBar = {
-            HomeHeader(
-                hasUnreadNotification = uiState.hasUnreadNotification,
-                onNotificationClick = onNotificationClick,
-                modifier = Modifier
-                    .padding(top = 24.dp)
-                    .padding(horizontal = 20.dp)
-            )
-        },
-        containerColor = feelinColors.backgroundPrimary,
-        modifier = Modifier
-            .windowInsetsPadding(WindowInsets.systemBars.only(WindowInsetsSides.Top))
-            .fillMaxSize()
-    ) { innerPadding ->
-        PullToRefreshBox(
-            isRefreshing = uiState.isRefreshing,
-            onRefresh = viewModel::refresh,
+    Box(modifier = modifier.fillMaxSize()) {
+        Scaffold(
+            topBar = {
+                HomeHeader(
+                    hasUnreadNotification = uiState.hasUnreadNotification,
+                    onNotificationClick = onNotificationClick,
+                    modifier = Modifier
+                        .padding(top = 24.dp)
+                        .padding(horizontal = 20.dp)
+                )
+            },
+            containerColor = feelinColors.backgroundPrimary,
             modifier = Modifier
+                .windowInsetsPadding(WindowInsets.systemBars.only(WindowInsetsSides.Top))
                 .fillMaxSize()
-                .padding(innerPadding)
-        ) {
-            LazyColumn(
-                modifier = Modifier.fillMaxSize(),
-                horizontalAlignment = Alignment.CenterHorizontally
+        ) { innerPadding ->
+            PullToRefreshBox(
+                isRefreshing = uiState.isRefreshing,
+                onRefresh = viewModel::refresh,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(innerPadding)
             ) {
-                uiState.banner?.let { banner ->
-                    item {
-                        BannerSection(
-                            banner = banner,
-                            onBannerClick = onBannerClick,
-                            modifier = Modifier
-                                .padding(vertical = 24.dp, horizontal = 20.dp)
-                        )
-                    }
-                }
-
-                // 배너가 아직 날아오지 않은 초기 로딩 상태에서 레이아웃 붕괴를 막기 위한 플레이스홀더다.
-                if (uiState.banner == null && uiState.errorMessage == null) {
-                    item {
-                        DummyBannerSection(
-                            modifier = Modifier.padding(vertical = 24.dp, horizontal = 20.dp)
-                        )
-                    }
-                }
-
-                // 풀투리프레시 등 초기 로딩이 아닌 시점의 오류는 본문 중앙에 별도 메시지를 노출한다.
-                if (uiState.errorMessage != null && !uiState.isInitialLoading) {
-                    item {
-                        Box(
-                            modifier = Modifier.fillMaxSize().padding(vertical = 40.dp),
-                            contentAlignment = Alignment.Center
-                        ) {
-                            Text(text = "데이터를 불러오는 중 오류가 발생했습니다.")
-                        }
-                    }
-                } else {
-                    if (uiState.artists.isNotEmpty()) {
+                LazyColumn(
+                    modifier = Modifier.fillMaxSize(),
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    uiState.banner?.let { banner ->
                         item {
-                            ArtistRow(
-                                artists = uiState.artists,
-                                onArtistClick = onArtistClick,
-                                onFindArtistsClick = {},
-                                onShowAllArtistsClick = {},
+                            BannerSection(
+                                banner = banner,
+                                onBannerClick = onBannerClick,
+                                modifier = Modifier
+                                    .padding(vertical = 24.dp, horizontal = 20.dp)
                             )
                         }
                     }
 
-                    if (uiState.isInitialLoading) {
-                        // 관심 아티스트 행 역시 로딩 중 레이아웃 높이를 유지하기 위해 더미 아이템을 보여준다.
+                    // 배너가 아직 날아오지 않은 초기 로딩 상태에서 레이아웃 붕괴를 막기 위한 플레이스홀더다.
+                    if (uiState.banner == null && uiState.errorMessage == null) {
                         item {
-                            ArtistRow(
-                                artists = listOf(
-                                    ArtistBubbleComponentData.HomeFavoriteSearchType(name = "찾아보기")
-                                ),
-                                onArtistClick = {},
-                                onFindArtistsClick = {},
-                                onShowAllArtistsClick = {},
+                            DummyBannerSection(
+                                modifier = Modifier.padding(vertical = 24.dp, horizontal = 20.dp)
                             )
                         }
                     }
 
-                    item {
-                        Spacer(
-                            modifier = Modifier
-                                .padding(top = 32.dp, bottom = 24.dp)
-                                .fillMaxWidth()
-                                .height(8.dp)
-                                .background(color = feelinColors.backgroundTertiary)
-                        )
-                    }
+                    // 풀투리프레시 등 초기 로딩이 아닌 시점의 오류는 본문 중앙에 별도 메시지를 노출한다.
+                    if (uiState.errorMessage != null && !uiState.isInitialLoading) {
+                        item {
+                            Box(
+                                modifier = Modifier.fillMaxSize().padding(vertical = 40.dp),
+                                contentAlignment = Alignment.Center
+                            ) {
+                                Text(text = "데이터를 불러오는 중 오류가 발생했습니다.")
+                            }
+                        }
+                    } else {
+                        if (uiState.artists.isNotEmpty()) {
+                            item {
+                                ArtistRow(
+                                    artists = uiState.artists,
+                                    onArtistClick = onArtistClick,
+                                    onShowAllArtistsClick = {},
+                                    onFindArtistsClick = {},
+                                )
+                            }
+                        }
 
-                    item {
-                        FeedSection(
-                            uiState = uiState,
-                            onTabClick = viewModel::selectTab,
-                            onFilterClick = viewModel::selectFilter,
-                            onNoteClick = onNoteClick,
-                            onNoteLikeClick = viewModel::toggleLike,
-                            onNoteBookmarkClick = viewModel::toggleBookmark
-                        )
+                        if (uiState.isInitialLoading) {
+                            // 관심 아티스트 행 역시 로딩 중 레이아웃 높이를 유지하기 위해 더미 아이템을 보여준다.
+                            item {
+                                ArtistRow(
+                                    artists = listOf(
+                                        ArtistBubbleComponentData.HomeFavoriteSearchType(name = "찾아보기")
+                                    ),
+                                    onArtistClick = {},
+                                    onShowAllArtistsClick = {},
+                                    onFindArtistsClick = {},
+                                )
+                            }
+                        }
+
+                        item {
+                            Spacer(
+                                modifier = Modifier
+                                    .padding(top = 32.dp, bottom = 24.dp)
+                                    .fillMaxWidth()
+                                    .height(8.dp)
+                                    .background(color = feelinColors.backgroundTertiary)
+                            )
+                        }
+
+                        item {
+                            FeedSection(
+                                uiState = uiState,
+                                onTabClick = viewModel::selectTab,
+                                onFilterClick = viewModel::selectFilter,
+                                onNoteClick = onNoteClick,
+                                onNoteLikeClick = viewModel::toggleLike,
+                                onNoteBookmarkClick = viewModel::toggleBookmark
+                            )
+                        }
                     }
                 }
             }
         }
-    }
 
-    // 최초 진입 시 전체 화면을 덮는 오버레이로, 중복 요청과 터치 이벤트를 차단한다.
-    if (uiState.isInitialLoading) {
-        Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .background(color = feelinColors.dim),
-            contentAlignment = Alignment.Center
-        ) {
-            CircularProgressIndicator()
+        // 최초 진입 시 전체 화면을 덮는 오버레이로, 중복 요청과 터치 이벤트를 차단한다.
+        if (uiState.isInitialLoading) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(color = feelinColors.dim),
+                contentAlignment = Alignment.Center
+            ) {
+                CircularProgressIndicator()
+            }
         }
-    }
 
-    if (uiState.errorMessage != null) {
-        // MARK: 실제 에러와 메시지 표현 필요
-        FeelinModalDialog(
-            title = uiState.errorMessage!!,
-            description = "에러코드 [-1]",
-            confirmButtonText = "확인",
-            onConfirmButtonClick = viewModel::clearError
-        )
+        if (uiState.errorMessage != null) {
+            // MARK: 실제 에러와 메시지 표현 필요
+            FeelinModalDialog(
+                title = uiState.errorMessage!!,
+                description = "에러코드 [-1]",
+                confirmButtonText = "확인",
+                onConfirmButtonClick = viewModel::clearError
+            )
+        }
     }
 }
 

--- a/app/src/main/java/com/lyrics/feelin/presentation/view/home/HomeUiState.kt
+++ b/app/src/main/java/com/lyrics/feelin/presentation/view/home/HomeUiState.kt
@@ -1,0 +1,25 @@
+package com.lyrics.feelin.presentation.view.home
+
+import com.lyrics.feelin.presentation.view.component.artist.ArtistBubbleComponentData
+import com.lyrics.feelin.presentation.view.home.component.Banner
+import com.lyrics.feelin.presentation.view.home.component.FeedTab
+import com.lyrics.feelin.presentation.view.home.component.FeedTabState
+
+/**
+ * 홈 화면의 UI 상태.
+ *
+ * 각 탭(FEED/ARTISTS)마다 독립적인 필터, 노트 목록, 페이징 상태를 유지한다.
+ */
+data class HomeUiState(
+    val banner: Banner? = null,
+    val artists: List<ArtistBubbleComponentData> = emptyList(),
+    val selectedTab: FeedTab = FeedTab.FEED,
+    val tabStates: Map<FeedTab, FeedTabState> = FeedTab.entries.associateWith { FeedTabState() },
+    val hasUnreadNotification: Boolean = false,
+    val isRefreshing: Boolean = false,
+    val isInitialLoading: Boolean = false,
+    val errorMessage: String? = null,
+) {
+    val currentTabState: FeedTabState
+        get() = tabStates.getValue(selectedTab)
+}

--- a/app/src/main/java/com/lyrics/feelin/presentation/view/home/HomeUiState.kt
+++ b/app/src/main/java/com/lyrics/feelin/presentation/view/home/HomeUiState.kt
@@ -14,6 +14,8 @@ data class HomeUiState(
     val banner: Banner? = null,
     val artists: List<ArtistBubbleComponentData> = emptyList(),
     val selectedTab: FeedTab = FeedTab.FEED,
+    /** 피드를 기존 방식(관심 아티스트 + 전체)으로만 보여줄지 신규 방식(전체/관심 탭, 아티스트 필터)으로 보여줄지 판단하는 플래그 */
+    val legacyMode: Boolean = false,
     val tabStates: Map<FeedTab, FeedTabState> = FeedTab.entries.associateWith { FeedTabState() },
     val hasUnreadNotification: Boolean = false,
     val isRefreshing: Boolean = false,

--- a/app/src/main/java/com/lyrics/feelin/presentation/view/home/HomeUiState.kt
+++ b/app/src/main/java/com/lyrics/feelin/presentation/view/home/HomeUiState.kt
@@ -15,7 +15,7 @@ data class HomeUiState(
     val artists: List<ArtistBubbleComponentData> = emptyList(),
     val selectedTab: FeedTab = FeedTab.FEED,
     /** 피드를 기존 방식(관심 아티스트 + 전체)으로만 보여줄지 신규 방식(전체/관심 탭, 아티스트 필터)으로 보여줄지 판단하는 플래그 */
-    val legacyMode: Boolean = false,
+    val legacyMode: Boolean = true,
     val tabStates: Map<FeedTab, FeedTabState> = FeedTab.entries.associateWith { FeedTabState() },
     val hasUnreadNotification: Boolean = false,
     val isRefreshing: Boolean = false,

--- a/app/src/main/java/com/lyrics/feelin/presentation/view/home/HomeViewModel.kt
+++ b/app/src/main/java/com/lyrics/feelin/presentation/view/home/HomeViewModel.kt
@@ -29,8 +29,17 @@ class HomeViewModel @Inject constructor() : ViewModel() {
     // 테스트에서 에러 경로를 검증하기 위한 스위치이며, 프로덕션 주입 생성자와는 분리되어 있다.
     private var shouldFailLoading = false
 
-    internal constructor(shouldFailLoading: Boolean) : this() {
+    internal constructor(shouldFailLoading: Boolean, initialLegacyMode: Boolean = false) : this() {
         this.shouldFailLoading = shouldFailLoading
+        _uiState.update { state ->
+            correctForLegacyMode(state.copy(legacyMode = initialLegacyMode))
+        }
+    }
+
+    internal fun setLegacyModeForTest(legacyMode: Boolean) {
+        _uiState.update { state ->
+            correctForLegacyMode(state.copy(legacyMode = legacyMode))
+        }
     }
 
     // 최초 진입 시 배너, 관심 아티스트, 그리고 모든 탭의 피드 상태를 한 번에 받아온다.
@@ -50,10 +59,13 @@ class HomeViewModel @Inject constructor() : ViewModel() {
                 createLoadedState()
             }.onSuccess { loadedState ->
                 _uiState.update { currentState ->
-                    loadedState.copy(
-                        selectedTab = currentState.selectedTab,
-                        isInitialLoading = false,
-                        isRefreshing = false,
+                    correctForLegacyMode(
+                        loadedState.copy(
+                            selectedTab = currentState.selectedTab,
+                            legacyMode = currentState.legacyMode,
+                            isInitialLoading = false,
+                            isRefreshing = false,
+                        )
                     )
                 }
             }.onFailure {
@@ -74,7 +86,7 @@ class HomeViewModel @Inject constructor() : ViewModel() {
         val selectedFilter = _uiState.value.currentTabState.selectedFilter
 
         _uiState.update { state ->
-            state.copy(isRefreshing = true, errorMessage = null)
+            correctForLegacyMode(state.copy(isRefreshing = true, errorMessage = null))
         }
 
         viewModelScope.launch {
@@ -96,16 +108,22 @@ class HomeViewModel @Inject constructor() : ViewModel() {
     }
 
     fun selectTab(tab: FeedTab) {
-        _uiState.update { state -> state.copy(selectedTab = tab) }
+        _uiState.update { state -> correctForLegacyMode(state.copy(selectedTab = tab)) }
     }
 
     // 필터가 바뀌면 기존 노트를 즉시 비우고, 선택한 필터의 첫 페이지를 새로 요청한다.
     fun selectFilter(filter: FilterButtonData) {
-        val selectedTab = _uiState.value.selectedTab
+        val currentState = _uiState.value
+        val selectedTab = if (currentState.legacyMode) FeedTab.ARTISTS else currentState.selectedTab
+        val selectedFilter = if (currentState.legacyMode) {
+            currentState.tabStates.getValue(FeedTab.ARTISTS).wholeFilter()
+        } else {
+            filter
+        }
 
         updateCurrentTabState { tabState ->
             tabState.copy(
-                selectedFilter = filter,
+                selectedFilter = selectedFilter,
                 notes = emptyList(),
                 isLoading = true,
             )
@@ -116,7 +134,7 @@ class HomeViewModel @Inject constructor() : ViewModel() {
             delay(LOAD_DELAY_MS.milliseconds)
             updateTabState(
                 tab = selectedTab,
-                tabState = createTabState(tab = selectedTab, selectedFilter = filter),
+                tabState = createTabState(tab = selectedTab, selectedFilter = selectedFilter),
             )
         }
     }
@@ -192,14 +210,33 @@ class HomeViewModel @Inject constructor() : ViewModel() {
         )
     }
 
+    private fun FeedTabState.wholeFilter(): FilterButtonData? {
+        return filters.firstOrNull { filter -> filter.name == WHOLE_FILTER_NAME }
+            ?: filters.firstOrNull()
+    }
+
+    private fun correctForLegacyMode(state: HomeUiState): HomeUiState {
+        if (!state.legacyMode) return state
+
+        val artistTabState = state.tabStates.getValue(FeedTab.ARTISTS)
+        val correctedArtistTabState = artistTabState.copy(selectedFilter = artistTabState.wholeFilter())
+
+        return state.copy(
+            selectedTab = FeedTab.ARTISTS,
+            tabStates = state.tabStates.plus(FeedTab.ARTISTS to correctedArtistTabState)
+        )
+    }
+
     // 현재 선택된 탭의 상태만 변경하고, 다른 탭의 필터/노트/페이징 상태는 그대로 보존한다.
     private fun updateCurrentTabState(transform: (FeedTabState) -> FeedTabState) {
         val selectedTab = _uiState.value.selectedTab
 
         _uiState.update { state ->
-            state.copy(
-                tabStates = state.tabStates.plus(
-                    selectedTab to transform(state.tabStates.getValue(selectedTab))
+            correctForLegacyMode(
+                state.copy(
+                    tabStates = state.tabStates.plus(
+                        selectedTab to transform(state.tabStates.getValue(selectedTab))
+                    )
                 )
             )
         }
@@ -211,8 +248,10 @@ class HomeViewModel @Inject constructor() : ViewModel() {
         transform: (HomeUiState) -> HomeUiState = { it },
     ) {
         _uiState.update { state ->
-            transform(
-                state.copy(tabStates = state.tabStates.plus(tab to tabState))
+            correctForLegacyMode(
+                transform(
+                    state.copy(tabStates = state.tabStates.plus(tab to tabState))
+                )
             )
         }
     }
@@ -221,8 +260,18 @@ class HomeViewModel @Inject constructor() : ViewModel() {
         private const val LOAD_DELAY_MS = 500L
         private const val LOAD_FAILURE_MESSAGE = "홈 데이터를 불러오지 못했어요."
         private const val LIKE_COUNT_DELTA = 1
+        private const val WHOLE_FILTER_NAME = "전체"
         private const val MIN_LIKE_COUNT = 0
 
+        internal fun createForTest(
+            shouldFailLoading: Boolean = false,
+            initialLegacyMode: Boolean = false,
+        ): HomeViewModel {
+            return HomeViewModel(
+                shouldFailLoading = shouldFailLoading,
+                initialLegacyMode = initialLegacyMode,
+            )
+        }
         private fun mockArtists(): List<ArtistBubbleComponentData> {
             return listOf(
                 ArtistBubbleComponentData.HomeFavoriteSearchType(name = "찾아보기"),

--- a/app/src/main/java/com/lyrics/feelin/presentation/view/home/HomeViewModel.kt
+++ b/app/src/main/java/com/lyrics/feelin/presentation/view/home/HomeViewModel.kt
@@ -22,17 +22,21 @@ import kotlinx.coroutines.launch
 @HiltViewModel
 class HomeViewModel @Inject constructor() : ViewModel() {
 
-    private val _uiState = MutableStateFlow(HomeUiState())
+    private val _uiState = MutableStateFlow(correctForLegacyMode(HomeUiState()))
     val uiState: StateFlow<HomeUiState> = _uiState.asStateFlow()
 
     // TODO(@이대근): 실연동시 삭제 및 테스트코드 수정 2026.06.17.
     // 테스트에서 에러 경로를 검증하기 위한 스위치이며, 프로덕션 주입 생성자와는 분리되어 있다.
     private var shouldFailLoading = false
 
-    internal constructor(shouldFailLoading: Boolean, initialLegacyMode: Boolean = false) : this() {
+    internal constructor(shouldFailLoading: Boolean, initialLegacyMode: Boolean = true) : this() {
         this.shouldFailLoading = shouldFailLoading
         _uiState.update { state ->
-            correctForLegacyMode(state.copy(legacyMode = initialLegacyMode))
+            if (initialLegacyMode) {
+                correctForLegacyMode(state.copy(legacyMode = true))
+            } else {
+                HomeUiState(legacyMode = false)
+            }
         }
     }
 
@@ -265,7 +269,7 @@ class HomeViewModel @Inject constructor() : ViewModel() {
 
         internal fun createForTest(
             shouldFailLoading: Boolean = false,
-            initialLegacyMode: Boolean = false,
+            initialLegacyMode: Boolean = true,
         ): HomeViewModel {
             return HomeViewModel(
                 shouldFailLoading = shouldFailLoading,

--- a/app/src/main/java/com/lyrics/feelin/presentation/view/home/HomeViewModel.kt
+++ b/app/src/main/java/com/lyrics/feelin/presentation/view/home/HomeViewModel.kt
@@ -1,0 +1,282 @@
+package com.lyrics.feelin.presentation.view.home
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.lyrics.feelin.core.designsystem.component.FilterButtonData
+import com.lyrics.feelin.presentation.view.component.artist.ArtistBubbleComponentData
+import com.lyrics.feelin.presentation.view.component.note.NoteComponentData
+import com.lyrics.feelin.presentation.view.home.component.Banner
+import com.lyrics.feelin.presentation.view.home.component.FeedTab
+import com.lyrics.feelin.presentation.view.home.component.FeedTabState
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlin.time.Duration.Companion.milliseconds
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+@Suppress("TooManyFunctions")
+@HiltViewModel
+class HomeViewModel @Inject constructor() : ViewModel() {
+
+    private val _uiState = MutableStateFlow(HomeUiState())
+    val uiState: StateFlow<HomeUiState> = _uiState.asStateFlow()
+
+    // TODO(@이대근): 실연동시 삭제 및 테스트코드 수정 2026.06.17.
+    // 테스트에서 에러 경로를 검증하기 위한 스위치이며, 프로덕션 주입 생성자와는 분리되어 있다.
+    private var shouldFailLoading = false
+
+    internal constructor(shouldFailLoading: Boolean) : this() {
+        this.shouldFailLoading = shouldFailLoading
+    }
+
+    // 최초 진입 시 배너, 관심 아티스트, 그리고 모든 탭의 피드 상태를 한 번에 받아온다.
+    fun loadHomeData() {
+        _uiState.update { state ->
+            state.copy(
+                isInitialLoading = true,
+                errorMessage = null,
+            )
+        }
+
+        viewModelScope.launch {
+            runCatching {
+                // TODO: 홈 Repository 연동 후 mock 데이터 대신 서버 응답으로 교체
+                delay(LOAD_DELAY_MS.milliseconds)
+                if (shouldFailLoading) error(LOAD_FAILURE_MESSAGE)
+                createLoadedState()
+            }.onSuccess { loadedState ->
+                _uiState.update { currentState ->
+                    loadedState.copy(
+                        selectedTab = currentState.selectedTab,
+                        isInitialLoading = false,
+                        isRefreshing = false,
+                    )
+                }
+            }.onFailure {
+                _uiState.update { state ->
+                    state.copy(
+                        isInitialLoading = false,
+                        isRefreshing = false,
+                        errorMessage = LOAD_FAILURE_MESSAGE,
+                    )
+                }
+            }
+        }
+    }
+
+    // 현재 탭과 선택된 필터를 유지한 채, 해당 탭의 피드만 새로고침한다.
+    fun refresh() {
+        val selectedTab = _uiState.value.selectedTab
+        val selectedFilter = _uiState.value.currentTabState.selectedFilter
+
+        _uiState.update { state ->
+            state.copy(isRefreshing = true, errorMessage = null)
+        }
+
+        viewModelScope.launch {
+            runCatching {
+                // TODO: 홈 Repository 연동 후 현재 탭 피드만 새로 요청
+                delay(LOAD_DELAY_MS.milliseconds)
+                if (shouldFailLoading) error(LOAD_FAILURE_MESSAGE)
+                createTabState(tab = selectedTab, selectedFilter = selectedFilter)
+            }.onSuccess { tabState ->
+                updateTabState(selectedTab, tabState) { state ->
+                    state.copy(isRefreshing = false)
+                }
+            }.onFailure {
+                _uiState.update { state ->
+                    state.copy(isRefreshing = false, errorMessage = LOAD_FAILURE_MESSAGE)
+                }
+            }
+        }
+    }
+
+    fun selectTab(tab: FeedTab) {
+        _uiState.update { state -> state.copy(selectedTab = tab) }
+    }
+
+    // 필터가 바뀌면 기존 노트를 즉시 비우고, 선택한 필터의 첫 페이지를 새로 요청한다.
+    fun selectFilter(filter: FilterButtonData) {
+        val selectedTab = _uiState.value.selectedTab
+
+        updateCurrentTabState { tabState ->
+            tabState.copy(
+                selectedFilter = filter,
+                notes = emptyList(),
+                isLoading = true,
+            )
+        }
+
+        viewModelScope.launch {
+            // TODO: 홈 Repository 연동 후 선택 필터로 피드 재요청
+            delay(LOAD_DELAY_MS.milliseconds)
+            updateTabState(
+                tab = selectedTab,
+                tabState = createTabState(tab = selectedTab, selectedFilter = filter),
+            )
+        }
+    }
+
+    // 서버 응답 전에 좋아요 상태와 개수를 낙관적으로 반영하여 UI가 끊기지 않게 한다.
+    fun toggleLike(noteId: Long) {
+        updateCurrentTabState { tabState ->
+            tabState.copy(
+                notes = tabState.notes.map { note ->
+                    if (note.id == noteId) {
+                        val likesCount = if (note.isLiked) {
+                            note.likesCount - LIKE_COUNT_DELTA
+                        } else {
+                            note.likesCount + LIKE_COUNT_DELTA
+                        }
+
+                        note.copy(
+                            isLiked = !note.isLiked,
+                            likesCount = likesCount.coerceAtLeast(MIN_LIKE_COUNT),
+                        )
+                    } else {
+                        note
+                    }
+                }
+            )
+        }
+    }
+
+    // 서버 응답 전에 북마크 상태를 낙관적으로 반영하여 UI가 끊기지 않게 한다.
+    fun toggleBookmark(noteId: Long) {
+        updateCurrentTabState { tabState ->
+            tabState.copy(
+                notes = tabState.notes.map { note ->
+                    if (note.id == noteId) note.copy(isBookmarked = !note.isBookmarked) else note
+                }
+            )
+        }
+    }
+
+    fun clearError() {
+        _uiState.update { state -> state.copy(errorMessage = null) }
+    }
+
+    private fun createLoadedState(): HomeUiState {
+        val currentState = _uiState.value
+        val tabStates = FeedTab.entries.associateWith { tab ->
+            val selectedFilter = currentState.tabStates[tab]?.selectedFilter
+            createTabState(tab = tab, selectedFilter = selectedFilter)
+        }
+
+        return currentState.copy(
+            banner = Banner(
+                imageUrl = "https://picsum.photos/seed/home-banner/800/320",
+                linkUrl = "https://example.com",
+            ),
+            artists = mockArtists(),
+            tabStates = tabStates,
+            hasUnreadNotification = true,
+            errorMessage = null,
+        )
+    }
+
+    private fun createTabState(tab: FeedTab, selectedFilter: FilterButtonData?): FeedTabState {
+        val filters = mockFilters()
+        val resolvedFilter = selectedFilter ?: filters.firstOrNull()
+
+        return FeedTabState(
+            filters = filters,
+            selectedFilter = resolvedFilter,
+            notes = mockNotes(tab = tab, selectedFilter = resolvedFilter),
+            isLoading = false,
+            hasMore = false,
+        )
+    }
+
+    // 현재 선택된 탭의 상태만 변경하고, 다른 탭의 필터/노트/페이징 상태는 그대로 보존한다.
+    private fun updateCurrentTabState(transform: (FeedTabState) -> FeedTabState) {
+        val selectedTab = _uiState.value.selectedTab
+
+        _uiState.update { state ->
+            state.copy(
+                tabStates = state.tabStates.plus(
+                    selectedTab to transform(state.tabStates.getValue(selectedTab))
+                )
+            )
+        }
+    }
+
+    private fun updateTabState(
+        tab: FeedTab,
+        tabState: FeedTabState,
+        transform: (HomeUiState) -> HomeUiState = { it },
+    ) {
+        _uiState.update { state ->
+            transform(
+                state.copy(tabStates = state.tabStates.plus(tab to tabState))
+            )
+        }
+    }
+
+    companion object {
+        private const val LOAD_DELAY_MS = 500L
+        private const val LOAD_FAILURE_MESSAGE = "홈 데이터를 불러오지 못했어요."
+        private const val LIKE_COUNT_DELTA = 1
+        private const val MIN_LIKE_COUNT = 0
+
+        private fun mockArtists(): List<ArtistBubbleComponentData> {
+            return listOf(
+                ArtistBubbleComponentData.HomeFavoriteSearchType(name = "찾아보기"),
+                ArtistBubbleComponentData.HomeFavoriteArtistType(
+                    id = 1L,
+                    name = "실리카겔",
+                    imageUrl = "https://picsum.photos/seed/silica-gel/200/200",
+                ),
+                ArtistBubbleComponentData.HomeFavoriteArtistType(
+                    id = 2L,
+                    name = "쏜애플",
+                    imageUrl = "https://picsum.photos/seed/thornapple/200/200",
+                ),
+            )
+        }
+
+        private fun mockFilters(): List<FilterButtonData> {
+            return listOf(
+                FilterButtonData(
+                    id = null,
+                    name = "전체",
+                    imageUrl = null
+                ),
+                FilterButtonData(
+                    id = null,
+                    name = "인기",
+                    imageUrl = null
+                ),
+                FilterButtonData(
+                    id = null,
+                    name = "해석공유",
+                    imageUrl = null,
+                ),
+            )
+        }
+
+        private fun mockNotes(tab: FeedTab, selectedFilter: FilterButtonData?): List<NoteComponentData> {
+            val tabOffset = if (tab == FeedTab.FEED) FEED_ID_OFFSET else ARTIST_ID_OFFSET
+            val filterOffset = selectedFilter?.id?.coerceAtLeast(MIN_FILTER_OFFSET) ?: MIN_FILTER_OFFSET
+
+            return List(MOCK_NOTE_COUNT) { index ->
+                NoteComponentData.sample().copy(
+                    id = tabOffset + filterOffset + index,
+                    content = "${selectedFilter?.name ?: "전체"} 홈 노트 ${index + NOTE_LABEL_OFFSET}",
+                    isLiked = false,
+                    isBookmarked = false,
+                )
+            }
+        }
+
+        private const val FEED_ID_OFFSET = 100L
+        private const val ARTIST_ID_OFFSET = 200L
+        private const val MIN_FILTER_OFFSET = 0L
+        private const val MOCK_NOTE_COUNT = 3
+        private const val NOTE_LABEL_OFFSET = 1
+    }
+}

--- a/app/src/main/java/com/lyrics/feelin/presentation/view/home/component/ArtistRow.kt
+++ b/app/src/main/java/com/lyrics/feelin/presentation/view/home/component/ArtistRow.kt
@@ -26,10 +26,10 @@ import com.lyrics.feelin.presentation.view.component.artist.ArtistBubbleComponen
 @Composable
 fun ArtistRow(
     artists: List<ArtistBubbleComponentData>,
-    modifier: Modifier = Modifier,
     onArtistClick: (Long) -> Unit,
     onShowAllArtistsClick: () -> Unit,
     onFindArtistsClick: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     val feelinColors = LocalFeelinColors.current
 

--- a/app/src/main/java/com/lyrics/feelin/presentation/view/home/component/ArtistRow.kt
+++ b/app/src/main/java/com/lyrics/feelin/presentation/view/home/component/ArtistRow.kt
@@ -1,0 +1,105 @@
+package com.lyrics.feelin.presentation.view.home.component
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.lyrics.feelin.presentation.designsystem.theme.FeelinTheme
+import com.lyrics.feelin.presentation.designsystem.theme.FeelinTypography
+import com.lyrics.feelin.presentation.designsystem.theme.LocalFeelinColors
+import com.lyrics.feelin.presentation.view.component.artist.ArtistBubbleComponent
+import com.lyrics.feelin.presentation.view.component.artist.ArtistBubbleComponentData
+
+@Composable
+fun ArtistRow(
+    artists: List<ArtistBubbleComponentData>,
+    modifier: Modifier = Modifier,
+    onArtistClick: (Long) -> Unit,
+    onShowAllArtistsClick: () -> Unit,
+    onFindArtistsClick: () -> Unit,
+) {
+    val feelinColors = LocalFeelinColors.current
+
+    Column(modifier = modifier.fillMaxWidth()) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 20.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = "나의 관심 아티스트",
+                style = FeelinTypography.heading3,
+                color = feelinColors.gray09
+            )
+            Text(
+                text = "전체보기",
+                style = FeelinTypography.title3,
+                color = feelinColors.systemActivate,
+                modifier = Modifier.clickable(onClick = onShowAllArtistsClick)
+            )
+        }
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        LazyRow(
+            contentPadding = PaddingValues(horizontal = 20.dp),
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            items(artists) { artist ->
+                // 아티스트 항목은 상세 페이지로, '찾아보기'는 아티스트 검색 화면으로 분기한다.
+                val onClick = when (artist) {
+                    is ArtistBubbleComponentData.HomeFavoriteArtistType -> {
+                        artist.id?.let { id -> { onArtistClick(id) } }
+                    }
+                    is ArtistBubbleComponentData.HomeFavoriteSearchType -> {
+                        onFindArtistsClick
+                    }
+                    else -> null
+                }
+                ArtistBubbleComponent(
+                    state = artist,
+                    onClick = onClick
+                )
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun ArtistRowPreview() {
+    FeelinTheme {
+        ArtistRow(
+            artists = listOf(
+                ArtistBubbleComponentData.HomeFavoriteSearchType(name = "찾아보기"),
+                ArtistBubbleComponentData.HomeFavoriteArtistType(
+                    name = "검정치마",
+                    imageUrl = "https://example.com/image.png"
+                ),
+                ArtistBubbleComponentData.HomeFavoriteArtistType(
+                    name = "혁오",
+                    imageUrl = "https://example.com/image.png"
+                )
+            ),
+            onArtistClick = {},
+            onFindArtistsClick = {},
+            onShowAllArtistsClick = {},
+        )
+    }
+}

--- a/app/src/main/java/com/lyrics/feelin/presentation/view/home/component/Banner.kt
+++ b/app/src/main/java/com/lyrics/feelin/presentation/view/home/component/Banner.kt
@@ -1,0 +1,3 @@
+package com.lyrics.feelin.presentation.view.home.component
+
+data class Banner(val imageUrl: String, val linkUrl: String)

--- a/app/src/main/java/com/lyrics/feelin/presentation/view/home/component/BannerSection.kt
+++ b/app/src/main/java/com/lyrics/feelin/presentation/view/home/component/BannerSection.kt
@@ -1,0 +1,64 @@
+package com.lyrics.feelin.presentation.view.home.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import coil3.compose.AsyncImage
+import com.lyrics.feelin.presentation.designsystem.theme.FeelinTheme
+import com.lyrics.feelin.presentation.designsystem.theme.LocalFeelinColors
+
+@Composable
+fun BannerSection(
+    banner: Banner,
+    onBannerClick: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    AsyncImage(
+        model = banner.imageUrl,
+        contentDescription = "Banner Image",
+        contentScale = ContentScale.Crop,
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(8.dp))
+            .clickable { onBannerClick(banner.linkUrl) }
+    )
+}
+
+/**
+ * 배너 이미지가 날아오지 않은 초기/로딩 상태에서 비율과 자리를 유지하는 플레이스홀더다.
+ */
+@Composable
+fun DummyBannerSection(modifier: Modifier = Modifier) {
+    val feelinColors = LocalFeelinColors.current
+
+    Box(
+        modifier = modifier
+            .height(110.dp)
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(8.dp))
+            .background(color = feelinColors.backgroundTertiary)
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun BannerSectionPreview() {
+    FeelinTheme {
+        BannerSection(
+            banner = Banner(
+                imageUrl = "https://example.com/banner.png",
+                linkUrl = "https://example.com",
+            ),
+            onBannerClick = {},
+        )
+    }
+}

--- a/app/src/main/java/com/lyrics/feelin/presentation/view/home/component/EmptyState.kt
+++ b/app/src/main/java/com/lyrics/feelin/presentation/view/home/component/EmptyState.kt
@@ -1,0 +1,65 @@
+package com.lyrics.feelin.presentation.view.home.component
+
+import android.content.res.Configuration
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.lyrics.feelin.core.designsystem.icon.EmptyImageDarkIcon
+import com.lyrics.feelin.core.designsystem.icon.EmptyImageLightIcon
+import com.lyrics.feelin.presentation.designsystem.theme.FeelinTheme
+import com.lyrics.feelin.presentation.designsystem.theme.FeelinTypography
+import com.lyrics.feelin.presentation.designsystem.theme.LocalFeelinColors
+
+@Composable
+fun EmptyState(modifier: Modifier = Modifier) {
+    val feelinColors = LocalFeelinColors.current
+    val isDark = isSystemInDarkTheme()
+    val icon = if (isDark) EmptyImageDarkIcon else EmptyImageLightIcon
+
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = "Empty State",
+            modifier = Modifier.size(78.dp),
+            tint = Color.Unspecified
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        Text(
+            text = "새로운 노트가 없어요",
+            style = FeelinTypography.body2,
+            color = feelinColors.gray04,
+            textAlign = TextAlign.Center
+        )
+    }
+}
+
+@Preview(showBackground = true, name = "Empty State - Light")
+@Preview(
+    showBackground = true,
+    backgroundColor = 0xFF0C0C0D,
+    name = "Empty State - Dark",
+    uiMode = Configuration.UI_MODE_NIGHT_YES
+)
+@Composable
+private fun EmptyStatePreview() {
+    FeelinTheme {
+        EmptyState()
+    }
+}

--- a/app/src/main/java/com/lyrics/feelin/presentation/view/home/component/FeedSection.kt
+++ b/app/src/main/java/com/lyrics/feelin/presentation/view/home/component/FeedSection.kt
@@ -1,112 +1,162 @@
 package com.lyrics.feelin.presentation.view.home.component
 
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.lyrics.feelin.core.designsystem.component.FeelinTab
 import com.lyrics.feelin.core.designsystem.component.FeelinTabRow
 import com.lyrics.feelin.core.designsystem.component.FilterButton
 import com.lyrics.feelin.core.designsystem.component.FilterButtonData
-import com.lyrics.feelin.presentation.designsystem.theme.FeelinTheme
 import com.lyrics.feelin.presentation.designsystem.theme.FeelinTypography
 import com.lyrics.feelin.presentation.designsystem.theme.LocalFeelinColors
 import com.lyrics.feelin.presentation.view.component.note.NoteComponent
+import com.lyrics.feelin.presentation.view.component.note.NoteComponentData
 import com.lyrics.feelin.presentation.view.home.HomeUiState
 
-@Composable
-fun FeedSection(
+/**
+ * 홈 화면의 피드 섹션을 [LazyListScope]에 직접 방출한다.
+ *
+ * 상위 [androidx.compose.foundation.lazy.LazyColumn]의 가상화를 유지하기 위해
+ * 이 컴포넌트는 독립적인 [androidx.compose.foundation.lazy.LazyColumn]이 아닌
+ * [LazyListScope] 확장 함수로 구현되어 있다.
+ */
+fun LazyListScope.feedSection(
     uiState: HomeUiState,
-    modifier: Modifier = Modifier,
     onTabClick: (FeedTab) -> Unit = {},
     onFilterClick: (FilterButtonData) -> Unit = {},
     onNoteClick: (Long) -> Unit = {},
     onNoteLikeClick: (Long) -> Unit = {},
-    onNoteBookmarkClick: (Long) -> Unit = {}
+    onNoteBookmarkClick: (Long) -> Unit = {},
 ) {
-    val feelinColors = LocalFeelinColors.current
-    val currentTabState = uiState.currentTabState
+    feedSectionHeader(
+        selectedTab = uiState.selectedTab,
+        legacyMode = uiState.legacyMode,
+        onTabClick = onTabClick
+    )
 
-    Column(modifier = modifier.fillMaxWidth()) {
+    if (!uiState.legacyMode) {
+        feedSectionFilters(
+            filters = uiState.currentTabState.filters,
+            selectedFilter = uiState.currentTabState.selectedFilter,
+            onFilterClick = onFilterClick
+        )
+    }
+
+    feedSectionNotes(
+        notes = uiState.currentTabState.notes,
+        onNoteClick = onNoteClick,
+        onNoteLikeClick = onNoteLikeClick,
+        onNoteBookmarkClick = onNoteBookmarkClick
+    )
+}
+
+private fun LazyListScope.feedSectionHeader(
+    selectedTab: FeedTab,
+    legacyMode: Boolean,
+    onTabClick: (FeedTab) -> Unit,
+) {
+    item(key = "feedHeader") {
+        val feelinColors = LocalFeelinColors.current
+
         Text(
             text = "따끈따끈한 노트",
             style = FeelinTypography.heading3,
             color = feelinColors.gray09,
-            modifier = Modifier.padding(horizontal = 20.dp)
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 20.dp)
         )
+    }
 
+    item(key = "feedHeaderSpacing") {
         Spacer(modifier = Modifier.height(8.dp))
+    }
 
-        if (!uiState.legacyMode) {
-            FeelinTabRow(
-                selectedTabIndex = uiState.selectedTab.ordinal,
-                modifier = Modifier.fillMaxWidth()
-            ) {
-                FeelinTab(
-                    selected = uiState.selectedTab == FeedTab.FEED,
-                    onClick = { onTabClick(FeedTab.FEED) },
-                    text = { Text("피드") }
-                )
-                FeelinTab(
-                    selected = uiState.selectedTab == FeedTab.ARTISTS,
-                    onClick = { onTabClick(FeedTab.ARTISTS) },
-                    text = { Text("관심 아티스트") }
-                )
-            }
+    if (legacyMode) return
 
-            Spacer(modifier = Modifier.height(20.dp))
-
-            if (currentTabState.filters.isNotEmpty()) {
-                LazyRow(
-                    modifier = Modifier.fillMaxWidth(),
-                    contentPadding = PaddingValues(horizontal = 20.dp),
-                    horizontalArrangement = Arrangement.spacedBy(8.dp)
-                ) {
-                    items(currentTabState.filters) { filter ->
-                        // MARK(@이대근): 담고 있는 데이터의 형태가 달라 같은 FliterButton을 유지할지 결정 필요
-                        FilterButton(
-                            data = filter,
-                            isSelect = currentTabState.selectedFilter?.id == filter.id,
-                            onClick = { onFilterClick(filter) }
-                        )
-                    }
-                }
-                Spacer(modifier = Modifier.height(16.dp))
-            }
+    item(key = "feedTabRow") {
+        FeelinTabRow(
+            selectedTabIndex = selectedTab.ordinal,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            FeelinTab(
+                selected = selectedTab == FeedTab.FEED,
+                onClick = { onTabClick(FeedTab.FEED) },
+                text = { Text("피드") }
+            )
+            FeelinTab(
+                selected = selectedTab == FeedTab.ARTISTS,
+                onClick = { onTabClick(FeedTab.ARTISTS) },
+                text = { Text("관심 아티스트") }
+            )
         }
+    }
 
-        if (currentTabState.notes.isEmpty()) {
-            EmptyState(modifier = Modifier.padding(top = 40.dp, bottom = 40.dp))
-        } else {
-            Column(modifier = Modifier.fillMaxWidth()) {
-                currentTabState.notes.forEach { note ->
-                    NoteComponent(
-                        noteData = note,
-                        onClick = { onNoteClick(note.id) },
-                        onLikeClick = { onNoteLikeClick(note.id) },
-                        onBookmarkClick = { onNoteBookmarkClick(note.id) },
-                        modifier = Modifier.fillMaxWidth()
-                    )
-                }
-            }
-        }
+    item(key = "feedTabSpacing") {
+        Spacer(modifier = Modifier.height(20.dp))
     }
 }
 
-@Preview(showBackground = true)
-@Composable
-private fun FeedSectionPreview() {
-    FeelinTheme {
-        FeedSection(uiState = HomeUiState())
+private fun LazyListScope.feedSectionFilters(
+    filters: List<FilterButtonData>,
+    selectedFilter: FilterButtonData?,
+    onFilterClick: (FilterButtonData) -> Unit,
+) {
+    if (filters.isEmpty()) return
+
+    item(key = "feedFilters") {
+        LazyRow(
+            modifier = Modifier.fillMaxWidth(),
+            contentPadding = PaddingValues(horizontal = 20.dp),
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            items(filters) { filter ->
+                // MARK(@이대근): 담고 있는 데이터의 형태가 달라 같은 FliterButton을 유지할지 결정 필요
+                FilterButton(
+                    data = filter,
+                    isSelect = selectedFilter?.id == filter.id,
+                    onClick = { onFilterClick(filter) }
+                )
+            }
+        }
+    }
+
+    item(key = "feedFilterSpacing") {
+        Spacer(modifier = Modifier.height(16.dp))
+    }
+}
+
+private fun LazyListScope.feedSectionNotes(
+    notes: List<NoteComponentData>,
+    onNoteClick: (Long) -> Unit,
+    onNoteLikeClick: (Long) -> Unit,
+    onNoteBookmarkClick: (Long) -> Unit,
+) {
+    if (notes.isEmpty()) {
+        item(key = "feedEmptyState") {
+            EmptyState(modifier = Modifier.padding(top = 40.dp, bottom = 40.dp))
+        }
+        return
+    }
+
+    items(
+        items = notes,
+        key = { note -> note.id },
+        contentType = { "NoteComponent" }
+    ) { note ->
+        NoteComponent(
+            noteData = note,
+            onClick = { onNoteClick(note.id) },
+            onLikeClick = { onNoteLikeClick(note.id) },
+            onBookmarkClick = { onNoteBookmarkClick(note.id) },
+            modifier = Modifier.fillMaxWidth()
+        )
     }
 }

--- a/app/src/main/java/com/lyrics/feelin/presentation/view/home/component/FeedSection.kt
+++ b/app/src/main/java/com/lyrics/feelin/presentation/view/home/component/FeedSection.kt
@@ -1,0 +1,110 @@
+package com.lyrics.feelin.presentation.view.home.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.lyrics.feelin.core.designsystem.component.FeelinTab
+import com.lyrics.feelin.core.designsystem.component.FeelinTabRow
+import com.lyrics.feelin.core.designsystem.component.FilterButton
+import com.lyrics.feelin.core.designsystem.component.FilterButtonData
+import com.lyrics.feelin.presentation.designsystem.theme.FeelinTheme
+import com.lyrics.feelin.presentation.designsystem.theme.FeelinTypography
+import com.lyrics.feelin.presentation.designsystem.theme.LocalFeelinColors
+import com.lyrics.feelin.presentation.view.component.note.NoteComponent
+import com.lyrics.feelin.presentation.view.home.HomeUiState
+
+@Composable
+fun FeedSection(
+    uiState: HomeUiState,
+    modifier: Modifier = Modifier,
+    onTabClick: (FeedTab) -> Unit = {},
+    onFilterClick: (FilterButtonData) -> Unit = {},
+    onNoteClick: (Long) -> Unit = {},
+    onNoteLikeClick: (Long) -> Unit = {},
+    onNoteBookmarkClick: (Long) -> Unit = {}
+) {
+    val feelinColors = LocalFeelinColors.current
+    val currentTabState = uiState.currentTabState
+
+    Column(modifier = modifier.fillMaxWidth()) {
+        Text(
+            text = "따끈따끈한 노트",
+            style = FeelinTypography.heading3,
+            color = feelinColors.gray09,
+            modifier = Modifier.padding(horizontal = 20.dp)
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        FeelinTabRow(
+            selectedTabIndex = uiState.selectedTab.ordinal,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            FeelinTab(
+                selected = uiState.selectedTab == FeedTab.FEED,
+                onClick = { onTabClick(FeedTab.FEED) },
+                text = { Text("피드") }
+            )
+            FeelinTab(
+                selected = uiState.selectedTab == FeedTab.ARTISTS,
+                onClick = { onTabClick(FeedTab.ARTISTS) },
+                text = { Text("관심 아티스트") }
+            )
+        }
+
+        Spacer(modifier = Modifier.height(20.dp))
+
+        if (currentTabState.filters.isNotEmpty()) {
+            LazyRow(
+                modifier = Modifier.fillMaxWidth(),
+                contentPadding = PaddingValues(horizontal = 20.dp),
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                items(currentTabState.filters) { filter ->
+                    // MARK(@이대근): 담고 있는 데이터의 형태가 달라 같은 FliterButton을 유지할지 결정 필요
+                    FilterButton(
+                        data = filter,
+                        isSelect = currentTabState.selectedFilter?.id == filter.id,
+                        onClick = { onFilterClick(filter) }
+                    )
+                }
+            }
+            Spacer(modifier = Modifier.height(16.dp))
+        }
+
+        if (currentTabState.notes.isEmpty()) {
+            EmptyState(modifier = Modifier.padding(top = 40.dp, bottom = 40.dp))
+        } else {
+            Column(modifier = Modifier.fillMaxWidth()) {
+                currentTabState.notes.forEach { note ->
+                    NoteComponent(
+                        noteData = note,
+                        onClick = { onNoteClick(note.id) },
+                        onLikeClick = { onNoteLikeClick(note.id) },
+                        onBookmarkClick = { onNoteBookmarkClick(note.id) },
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun FeedSectionPreview() {
+    FeelinTheme {
+        FeedSection(uiState = HomeUiState())
+    }
+}

--- a/app/src/main/java/com/lyrics/feelin/presentation/view/home/component/FeedSection.kt
+++ b/app/src/main/java/com/lyrics/feelin/presentation/view/home/component/FeedSection.kt
@@ -47,40 +47,42 @@ fun FeedSection(
 
         Spacer(modifier = Modifier.height(8.dp))
 
-        FeelinTabRow(
-            selectedTabIndex = uiState.selectedTab.ordinal,
-            modifier = Modifier.fillMaxWidth()
-        ) {
-            FeelinTab(
-                selected = uiState.selectedTab == FeedTab.FEED,
-                onClick = { onTabClick(FeedTab.FEED) },
-                text = { Text("피드") }
-            )
-            FeelinTab(
-                selected = uiState.selectedTab == FeedTab.ARTISTS,
-                onClick = { onTabClick(FeedTab.ARTISTS) },
-                text = { Text("관심 아티스트") }
-            )
-        }
-
-        Spacer(modifier = Modifier.height(20.dp))
-
-        if (currentTabState.filters.isNotEmpty()) {
-            LazyRow(
-                modifier = Modifier.fillMaxWidth(),
-                contentPadding = PaddingValues(horizontal = 20.dp),
-                horizontalArrangement = Arrangement.spacedBy(8.dp)
+        if (!uiState.legacyMode) {
+            FeelinTabRow(
+                selectedTabIndex = uiState.selectedTab.ordinal,
+                modifier = Modifier.fillMaxWidth()
             ) {
-                items(currentTabState.filters) { filter ->
-                    // MARK(@이대근): 담고 있는 데이터의 형태가 달라 같은 FliterButton을 유지할지 결정 필요
-                    FilterButton(
-                        data = filter,
-                        isSelect = currentTabState.selectedFilter?.id == filter.id,
-                        onClick = { onFilterClick(filter) }
-                    )
-                }
+                FeelinTab(
+                    selected = uiState.selectedTab == FeedTab.FEED,
+                    onClick = { onTabClick(FeedTab.FEED) },
+                    text = { Text("피드") }
+                )
+                FeelinTab(
+                    selected = uiState.selectedTab == FeedTab.ARTISTS,
+                    onClick = { onTabClick(FeedTab.ARTISTS) },
+                    text = { Text("관심 아티스트") }
+                )
             }
-            Spacer(modifier = Modifier.height(16.dp))
+
+            Spacer(modifier = Modifier.height(20.dp))
+
+            if (currentTabState.filters.isNotEmpty()) {
+                LazyRow(
+                    modifier = Modifier.fillMaxWidth(),
+                    contentPadding = PaddingValues(horizontal = 20.dp),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    items(currentTabState.filters) { filter ->
+                        // MARK(@이대근): 담고 있는 데이터의 형태가 달라 같은 FliterButton을 유지할지 결정 필요
+                        FilterButton(
+                            data = filter,
+                            isSelect = currentTabState.selectedFilter?.id == filter.id,
+                            onClick = { onFilterClick(filter) }
+                        )
+                    }
+                }
+                Spacer(modifier = Modifier.height(16.dp))
+            }
         }
 
         if (currentTabState.notes.isEmpty()) {

--- a/app/src/main/java/com/lyrics/feelin/presentation/view/home/component/FeedTab.kt
+++ b/app/src/main/java/com/lyrics/feelin/presentation/view/home/component/FeedTab.kt
@@ -1,0 +1,6 @@
+package com.lyrics.feelin.presentation.view.home.component
+
+enum class FeedTab {
+    FEED,
+    ARTISTS,
+}

--- a/app/src/main/java/com/lyrics/feelin/presentation/view/home/component/FeedTabState.kt
+++ b/app/src/main/java/com/lyrics/feelin/presentation/view/home/component/FeedTabState.kt
@@ -1,0 +1,17 @@
+package com.lyrics.feelin.presentation.view.home.component
+
+import com.lyrics.feelin.core.designsystem.component.FilterButtonData
+import com.lyrics.feelin.presentation.view.component.note.NoteComponentData
+
+/**
+ * 피드 탭별 상태.
+ *
+ * 탭을 전환할 때도 선택한 필터와 노트 목록이 보존되어야 한다.
+ */
+data class FeedTabState(
+    val filters: List<FilterButtonData> = emptyList(),
+    val selectedFilter: FilterButtonData? = null,
+    val notes: List<NoteComponentData> = emptyList(),
+    val isLoading: Boolean = false,
+    val hasMore: Boolean = false,
+)

--- a/app/src/main/java/com/lyrics/feelin/presentation/view/home/component/HomeHeader.kt
+++ b/app/src/main/java/com/lyrics/feelin/presentation/view/home/component/HomeHeader.kt
@@ -64,7 +64,7 @@ fun HomeHeader(
 @Preview(
     showBackground = true,
     name = "Home Header - Dark Theme",
-    backgroundColor = 0xFF00000,
+    backgroundColor = 0xFF000000,
     uiMode = Configuration.UI_MODE_NIGHT_YES
 )
 @Composable
@@ -81,7 +81,7 @@ private fun HomeHeaderPreview() {
 @Preview(
     showBackground = true,
     name = "Home Header Unread - Dark Theme",
-    backgroundColor = 0xFF00000,
+    backgroundColor = 0xFF000000,
     uiMode = Configuration.UI_MODE_NIGHT_YES
 )
 @Composable

--- a/app/src/main/java/com/lyrics/feelin/presentation/view/home/component/HomeHeader.kt
+++ b/app/src/main/java/com/lyrics/feelin/presentation/view/home/component/HomeHeader.kt
@@ -1,0 +1,95 @@
+package com.lyrics.feelin.presentation.view.home.component
+
+import android.content.res.Configuration
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.lyrics.feelin.core.designsystem.icon.FeelinTextIcon
+import com.lyrics.feelin.core.designsystem.icon.NotificationIconDark
+import com.lyrics.feelin.core.designsystem.icon.NotificationIconLight
+import com.lyrics.feelin.core.designsystem.icon.NotificationWithBadgeIconDark
+import com.lyrics.feelin.core.designsystem.icon.NotificationWithBadgeIconLight
+import com.lyrics.feelin.presentation.designsystem.theme.FeelinTheme
+import com.lyrics.feelin.presentation.designsystem.theme.LocalFeelinColors
+
+@Composable
+fun HomeHeader(
+    hasUnreadNotification: Boolean,
+    onNotificationClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val feelinColors = LocalFeelinColors.current
+    val isDarkTheme = isSystemInDarkTheme()
+
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Icon(
+            imageVector = FeelinTextIcon,
+            contentDescription = "Feelin Logo",
+            tint = feelinColors.gray09,
+            modifier = Modifier.width(83.dp)
+        )
+
+        // TODO(@이대근): 라이트모드/다크모드 에셋 분리해 표시
+        val notificationIcon = when {
+            hasUnreadNotification && isDarkTheme -> NotificationWithBadgeIconDark
+            hasUnreadNotification -> NotificationWithBadgeIconLight
+            isDarkTheme -> NotificationIconDark
+            else -> NotificationIconLight
+        }
+
+        Icon(
+            imageVector = notificationIcon,
+            contentDescription = "Notification",
+            modifier = Modifier.clickable(onClick = onNotificationClick),
+            tint = Color.Unspecified
+        )
+    }
+}
+
+@Preview(showBackground = true, name = "Home Header - Light Theme")
+@Preview(
+    showBackground = true,
+    name = "Home Header - Dark Theme",
+    backgroundColor = 0xFF00000,
+    uiMode = Configuration.UI_MODE_NIGHT_YES
+)
+@Composable
+private fun HomeHeaderPreview() {
+    FeelinTheme {
+        HomeHeader(
+            hasUnreadNotification = false,
+            onNotificationClick = {},
+        )
+    }
+}
+
+@Preview(showBackground = true, name = "Home Header Unread - Light Theme")
+@Preview(
+    showBackground = true,
+    name = "Home Header Unread - Dark Theme",
+    backgroundColor = 0xFF00000,
+    uiMode = Configuration.UI_MODE_NIGHT_YES
+)
+@Composable
+private fun HomeHeaderUnreadPreview() {
+    FeelinTheme {
+        HomeHeader(
+            hasUnreadNotification = true,
+            onNotificationClick = {},
+        )
+    }
+}

--- a/app/src/main/java/com/lyrics/feelin/presentation/view/mypage/MyPageScreen.kt
+++ b/app/src/main/java/com/lyrics/feelin/presentation/view/mypage/MyPageScreen.kt
@@ -53,7 +53,7 @@ import com.lyrics.feelin.core.designsystem.component.TopBarIconButton
 import com.lyrics.feelin.core.designsystem.icon.CaretIcon
 import com.lyrics.feelin.core.designsystem.icon.EmptyImageDarkIcon
 import com.lyrics.feelin.core.designsystem.icon.EmptyImageLightIcon
-import com.lyrics.feelin.core.designsystem.icon.NotificationIcon
+import com.lyrics.feelin.core.designsystem.icon.NotificationIconLight
 import com.lyrics.feelin.core.designsystem.icon.SettingsIconLight
 import com.lyrics.feelin.core.domain.model.ProfileType
 import com.lyrics.feelin.presentation.designsystem.theme.FeelinTheme
@@ -103,7 +103,7 @@ fun MyPageScreen(
                         onClick = onSettingClick
                     )
                     TopBarIconButton(
-                        imageVector = NotificationIcon,
+                        imageVector = NotificationIconLight,
                         contentDescription = "알림",
                         tint = feelinColors.gray09,
                         onClick = {}

--- a/app/src/test/java/com/lyrics/feelin/presentation/view/home/FeedTabStateTest.kt
+++ b/app/src/test/java/com/lyrics/feelin/presentation/view/home/FeedTabStateTest.kt
@@ -1,0 +1,16 @@
+package com.lyrics.feelin.presentation.view.home
+
+import com.lyrics.feelin.presentation.view.home.component.FeedTabState
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class FeedTabStateTest {
+
+    @Test
+    fun defaultStateHasEmptyNotesAndFilters() {
+        val state = FeedTabState()
+
+        assertTrue(state.notes.isEmpty())
+        assertTrue(state.filters.isEmpty())
+    }
+}

--- a/app/src/test/java/com/lyrics/feelin/presentation/view/home/HomeUiStateTest.kt
+++ b/app/src/test/java/com/lyrics/feelin/presentation/view/home/HomeUiStateTest.kt
@@ -4,7 +4,6 @@ import com.lyrics.feelin.core.designsystem.component.FilterButtonData
 import com.lyrics.feelin.presentation.view.home.component.FeedTab
 import com.lyrics.feelin.presentation.view.home.component.FeedTabState
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -45,8 +44,9 @@ class HomeUiStateTest {
 
     @Test
     fun errorStateExposesMessage() {
-        val state = HomeUiState(errorMessage = "홈 피드를 불러오지 못했어요.")
+        val expected = "홈 피드를 불러오지 못했어요."
+        val state = HomeUiState(errorMessage = expected)
 
-        assertNotNull(state.errorMessage)
+        assertEquals(expected, state.errorMessage)
     }
 }

--- a/app/src/test/java/com/lyrics/feelin/presentation/view/home/HomeUiStateTest.kt
+++ b/app/src/test/java/com/lyrics/feelin/presentation/view/home/HomeUiStateTest.kt
@@ -1,0 +1,51 @@
+package com.lyrics.feelin.presentation.view.home
+
+import com.lyrics.feelin.core.designsystem.component.FilterButtonData
+import com.lyrics.feelin.presentation.view.home.component.FeedTab
+import com.lyrics.feelin.presentation.view.home.component.FeedTabState
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class HomeUiStateTest {
+
+    @Test
+    fun defaultStateHasFeedTabActive() {
+        val state = HomeUiState()
+
+        assertEquals(FeedTab.FEED, state.selectedTab)
+    }
+
+    @Test
+    fun tabSwitchPreservesSelectedFilter() {
+        val selectedFilter = FilterButtonData(id = 1L, name = "실리카겔", imageUrl = "https://picsum.photos/200")
+        val feedState = FeedTabState(
+            filters = listOf(selectedFilter),
+            selectedFilter = selectedFilter,
+        )
+        val state = HomeUiState(
+            tabStates = FeedTab.entries.associateWith { FeedTabState() }
+                .plus(FeedTab.FEED to feedState),
+        )
+
+        val switchedState = state.copy(selectedTab = FeedTab.ARTISTS)
+            .copy(selectedTab = FeedTab.FEED)
+
+        assertEquals(selectedFilter, switchedState.currentTabState.selectedFilter)
+    }
+
+    @Test
+    fun emptyNotesListShowsEmptyFlag() {
+        val state = HomeUiState()
+
+        assertTrue(state.tabStates[FeedTab.FEED]!!.notes.isEmpty())
+    }
+
+    @Test
+    fun errorStateExposesMessage() {
+        val state = HomeUiState(errorMessage = "홈 피드를 불러오지 못했어요.")
+
+        assertNotNull(state.errorMessage)
+    }
+}

--- a/app/src/test/java/com/lyrics/feelin/presentation/view/home/HomeUiStateTest.kt
+++ b/app/src/test/java/com/lyrics/feelin/presentation/view/home/HomeUiStateTest.kt
@@ -15,6 +15,7 @@ class HomeUiStateTest {
         val state = HomeUiState()
 
         assertEquals(FeedTab.FEED, state.selectedTab)
+        assertEquals(false, state.legacyMode)
     }
 
     @Test

--- a/app/src/test/java/com/lyrics/feelin/presentation/view/home/HomeUiStateTest.kt
+++ b/app/src/test/java/com/lyrics/feelin/presentation/view/home/HomeUiStateTest.kt
@@ -15,7 +15,7 @@ class HomeUiStateTest {
         val state = HomeUiState()
 
         assertEquals(FeedTab.FEED, state.selectedTab)
-        assertEquals(false, state.legacyMode)
+        assertEquals(true, state.legacyMode)
     }
 
     @Test

--- a/app/src/test/java/com/lyrics/feelin/presentation/view/home/HomeViewModelTest.kt
+++ b/app/src/test/java/com/lyrics/feelin/presentation/view/home/HomeViewModelTest.kt
@@ -30,7 +30,7 @@ class HomeViewModelTest {
 
     @Before
     fun setUp() {
-        viewModel = HomeViewModel()
+        viewModel = HomeViewModel.createForTest(initialLegacyMode = false)
     }
 
     @After
@@ -53,7 +53,7 @@ class HomeViewModelTest {
     }
 
     @Test
-    fun defaultModeLoadKeepsFeedWholeFilter() = runTest {
+    fun currentModeLoadKeepsFeedWholeFilter() = runTest {
         viewModel.loadHomeData()
         advanceUntilIdle()
 
@@ -61,6 +61,23 @@ class HomeViewModelTest {
 
         assertFalse(state.legacyMode)
         assertEquals(FeedTab.FEED, state.selectedTab)
+        assertEquals("전체", state.currentTabState.selectedFilter?.name)
+    }
+
+    @Test
+    fun defaultViewModelStartsInLegacyMode() = runTest {
+        val defaultViewModel = HomeViewModel()
+
+        assertTrue(defaultViewModel.uiState.value.legacyMode)
+        assertEquals(FeedTab.ARTISTS, defaultViewModel.uiState.value.selectedTab)
+
+        defaultViewModel.loadHomeData()
+        advanceUntilIdle()
+
+        val state = defaultViewModel.uiState.value
+
+        assertTrue(state.legacyMode)
+        assertEquals(FeedTab.ARTISTS, state.selectedTab)
         assertEquals("전체", state.currentTabState.selectedFilter?.name)
     }
 

--- a/app/src/test/java/com/lyrics/feelin/presentation/view/home/HomeViewModelTest.kt
+++ b/app/src/test/java/com/lyrics/feelin/presentation/view/home/HomeViewModelTest.kt
@@ -53,6 +53,36 @@ class HomeViewModelTest {
     }
 
     @Test
+    fun defaultModeLoadKeepsFeedWholeFilter() = runTest {
+        viewModel.loadHomeData()
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+
+        assertFalse(state.legacyMode)
+        assertEquals(FeedTab.FEED, state.selectedTab)
+        assertEquals("전체", state.currentTabState.selectedFilter?.name)
+    }
+
+    @Test
+    fun legacyModeInitialAndLoadForceArtistsWholeFilter() = runTest {
+        val legacyViewModel = HomeViewModel.createForTest(initialLegacyMode = true)
+
+        assertTrue(legacyViewModel.uiState.value.legacyMode)
+        assertEquals(FeedTab.ARTISTS, legacyViewModel.uiState.value.selectedTab)
+
+        legacyViewModel.loadHomeData()
+        advanceUntilIdle()
+
+        val state = legacyViewModel.uiState.value
+
+        assertTrue(state.legacyMode)
+        assertEquals(FeedTab.ARTISTS, state.selectedTab)
+        assertEquals("전체", state.currentTabState.selectedFilter?.name)
+        assertEquals(state.currentTabState.filters.first(), state.currentTabState.selectedFilter)
+    }
+
+    @Test
     fun selectTabKeepsExistingFilter() = runTest {
         viewModel.loadHomeData()
         advanceUntilIdle()
@@ -114,6 +144,98 @@ class HomeViewModelTest {
         assertTrue(viewModel.uiState.value.isRefreshing)
         advanceUntilIdle()
         assertFalse(viewModel.uiState.value.isRefreshing)
+    }
+
+    @Test
+    fun legacyModeRefreshKeepsArtistsWholeFilter() = runTest {
+        val legacyViewModel = HomeViewModel.createForTest(initialLegacyMode = true)
+        legacyViewModel.loadHomeData()
+        advanceUntilIdle()
+
+        legacyViewModel.refresh()
+        advanceUntilIdle()
+
+        val state = legacyViewModel.uiState.value
+
+        assertEquals(FeedTab.ARTISTS, state.selectedTab)
+        assertEquals("전체", state.currentTabState.selectedFilter?.name)
+        assertEquals(state.currentTabState.filters.first(), state.currentTabState.selectedFilter)
+        assertFalse(state.isRefreshing)
+    }
+
+    @Test
+    fun legacyModeSelectTabReturnsToArtists() = runTest {
+        val legacyViewModel = HomeViewModel.createForTest(initialLegacyMode = true)
+        legacyViewModel.loadHomeData()
+        advanceUntilIdle()
+
+        legacyViewModel.selectTab(FeedTab.FEED)
+
+        assertEquals(FeedTab.ARTISTS, legacyViewModel.uiState.value.selectedTab)
+        assertEquals(
+            legacyViewModel.uiState.value.currentTabState.filters.first(),
+            legacyViewModel.uiState.value.currentTabState.selectedFilter,
+        )
+        assertEquals("전체", legacyViewModel.uiState.value.currentTabState.selectedFilter?.name)
+    }
+
+    @Test
+    fun legacyModeSelectFilterKeepsArtistsWholeFilterImmediatelyAndAfterLoad() = runTest {
+        val legacyViewModel = HomeViewModel.createForTest(initialLegacyMode = true)
+        legacyViewModel.loadHomeData()
+        advanceUntilIdle()
+        val nextFilter = legacyViewModel.uiState.value.currentTabState.filters[1]
+
+        legacyViewModel.selectFilter(nextFilter)
+
+        assertEquals(FeedTab.ARTISTS, legacyViewModel.uiState.value.selectedTab)
+        assertEquals("전체", legacyViewModel.uiState.value.currentTabState.selectedFilter?.name)
+        assertEquals(
+            legacyViewModel.uiState.value.currentTabState.filters.first(),
+            legacyViewModel.uiState.value.currentTabState.selectedFilter,
+        )
+        assertTrue(legacyViewModel.uiState.value.currentTabState.notes.isEmpty())
+
+        advanceUntilIdle()
+
+        assertEquals(FeedTab.ARTISTS, legacyViewModel.uiState.value.selectedTab)
+        assertEquals("전체", legacyViewModel.uiState.value.currentTabState.selectedFilter?.name)
+        assertEquals(
+            legacyViewModel.uiState.value.currentTabState.filters.first(),
+            legacyViewModel.uiState.value.currentTabState.selectedFilter,
+        )
+        assertTrue(
+            legacyViewModel.uiState.value.currentTabState.notes.all { note ->
+                note.content.startsWith("전체")
+            }
+        )
+        assertTrue(legacyViewModel.uiState.value.currentTabState.notes.isNotEmpty())
+    }
+
+    @Test
+    fun legacyModeTransitionToCurrentModeStartsFromArtistsThenAllowsSelection() = runTest {
+        val legacyViewModel = HomeViewModel.createForTest(initialLegacyMode = true)
+        legacyViewModel.loadHomeData()
+        advanceUntilIdle()
+
+        legacyViewModel.setLegacyModeForTest(false)
+
+        assertFalse(legacyViewModel.uiState.value.legacyMode)
+        assertEquals(FeedTab.ARTISTS, legacyViewModel.uiState.value.selectedTab)
+        assertEquals("전체", legacyViewModel.uiState.value.currentTabState.selectedFilter?.name)
+        assertEquals(
+            legacyViewModel.uiState.value.currentTabState.filters.first(),
+            legacyViewModel.uiState.value.currentTabState.selectedFilter,
+        )
+
+        legacyViewModel.selectTab(FeedTab.FEED)
+
+        assertEquals(FeedTab.FEED, legacyViewModel.uiState.value.selectedTab)
+
+        val nextFilter = legacyViewModel.uiState.value.currentTabState.filters[1]
+        legacyViewModel.selectFilter(nextFilter)
+
+        assertEquals(nextFilter, legacyViewModel.uiState.value.currentTabState.selectedFilter)
     }
 
     @Test

--- a/app/src/test/java/com/lyrics/feelin/presentation/view/home/HomeViewModelTest.kt
+++ b/app/src/test/java/com/lyrics/feelin/presentation/view/home/HomeViewModelTest.kt
@@ -1,0 +1,152 @@
+package com.lyrics.feelin.presentation.view.home
+
+import com.lyrics.feelin.presentation.view.home.component.FeedTab
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class HomeViewModelTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private lateinit var viewModel: HomeViewModel
+
+    @Before
+    fun setUp() {
+        viewModel = HomeViewModel()
+    }
+
+    @After
+    fun tearDown() {
+        viewModel.clearError()
+    }
+
+    @Test
+    fun loadHomeDataPopulatesBannerArtistsAndNotes() = runTest {
+        viewModel.loadHomeData()
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+
+        assertNotNull(state.banner)
+        assertTrue(state.artists.isNotEmpty())
+        assertTrue(state.currentTabState.filters.isNotEmpty())
+        assertTrue(state.currentTabState.notes.isNotEmpty())
+        assertFalse(state.isInitialLoading)
+    }
+
+    @Test
+    fun selectTabKeepsExistingFilter() = runTest {
+        viewModel.loadHomeData()
+        advanceUntilIdle()
+        val feedFilter = viewModel.uiState.value.currentTabState.filters[1]
+        viewModel.selectFilter(feedFilter)
+        advanceUntilIdle()
+
+        viewModel.selectTab(FeedTab.ARTISTS)
+        advanceUntilIdle()
+        viewModel.selectTab(FeedTab.FEED)
+
+        assertEquals(feedFilter, viewModel.uiState.value.currentTabState.selectedFilter)
+    }
+
+    @Test
+    fun selectFilterClearsNotes() = runTest {
+        viewModel.loadHomeData()
+        advanceUntilIdle()
+        val nextFilter = viewModel.uiState.value.currentTabState.filters[1]
+
+        viewModel.selectFilter(nextFilter)
+
+        assertEquals(nextFilter, viewModel.uiState.value.currentTabState.selectedFilter)
+        assertTrue(viewModel.uiState.value.currentTabState.notes.isEmpty())
+    }
+
+    @Test
+    fun toggleLikeUpdatesImmediately() = runTest {
+        viewModel.loadHomeData()
+        advanceUntilIdle()
+        val note = viewModel.uiState.value.currentTabState.notes.first()
+
+        viewModel.toggleLike(note.id)
+
+        val updatedNote = viewModel.uiState.value.currentTabState.notes.first { it.id == note.id }
+        assertTrue(updatedNote.isLiked)
+        assertEquals(note.likesCount + 1, updatedNote.likesCount)
+    }
+
+    @Test
+    fun toggleBookmarkUpdatesImmediately() = runTest {
+        viewModel.loadHomeData()
+        advanceUntilIdle()
+        val note = viewModel.uiState.value.currentTabState.notes.first()
+
+        viewModel.toggleBookmark(note.id)
+
+        val updatedNote = viewModel.uiState.value.currentTabState.notes.first { it.id == note.id }
+        assertTrue(updatedNote.isBookmarked)
+    }
+
+    @Test
+    fun refreshSetsAndClearsIsRefreshing() = runTest {
+        viewModel.loadHomeData()
+        advanceUntilIdle()
+
+        viewModel.refresh()
+
+        assertTrue(viewModel.uiState.value.isRefreshing)
+        advanceUntilIdle()
+        assertFalse(viewModel.uiState.value.isRefreshing)
+    }
+
+    @Test
+    fun initialLoadShowsOverlay() = runTest {
+        viewModel.loadHomeData()
+
+        assertTrue(viewModel.uiState.value.isInitialLoading)
+        advanceUntilIdle()
+        assertFalse(viewModel.uiState.value.isInitialLoading)
+    }
+
+    @Test
+    fun loadFailureShowsErrorMessage() = runTest {
+        val failingViewModel = HomeViewModel(shouldFailLoading = true)
+
+        failingViewModel.loadHomeData()
+        advanceUntilIdle()
+
+        assertEquals("홈 데이터를 불러오지 못했어요.", failingViewModel.uiState.value.errorMessage)
+        assertFalse(failingViewModel.uiState.value.isInitialLoading)
+    }
+}
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MainDispatcherRule(
+    private val testDispatcher: TestDispatcher = StandardTestDispatcher()
+) : TestWatcher() {
+
+    override fun starting(description: Description) {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    override fun finished(description: Description) {
+        Dispatchers.resetMain()
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,7 @@ hilt = "2.57.2"
 kotlin = "2.2.0"
 datastore = "1.1.7"
 kotlinxDatetime = "0.7.1"
+kotlinxCoroutines = "1.11.0"
 ksp = "2.2.0-2.0.2"
 coreKtx = "1.16.0"
 junit = "4.13.2"
@@ -45,6 +46,7 @@ hilt-compiler = { module = "com.google.dagger:hilt-compiler", version.ref = "hil
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastore" }
 kotlinx-datetime = { group = "org.jetbrains.kotlinx", name = "kotlinx-datetime", version.ref = "kotlinxDatetime" }
+kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinxCoroutines" }
 androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }
 androidx-hilt-navigation-compose = { group = "androidx.hilt", name = "hilt-navigation-compose", version = "1.2.0" }
 androidx-webkit = { group = "androidx.webkit", name = "webkit", version.ref = "webkit" }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features) - AI agent generated
<!-- - [ ] Docs have been added / updated (for bug fixes / features) -->


## What kind of change does this PR introduce?

- Implement design


# What is the current behavior?

홈 화면이 디자인과 기능 모두 구현되지 않은 상태입니다.


# What is the new behavior (if this is a feature change)?

홈 화면의 디자인을 구현합니다. 또한 해당 화면을 내비게이션에 등록합니다.
홈 화면은 기존 서버의 API호환을 위한 기존 디자인과 개편 이후 디자인을 모두 대응합니다.


## Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No breaking changes.


## ScreenShots (If needed)
### Legacy layout

#### Light mode

<p>
  <img width="300" alt="Screenshot_20260618_130930_ DEV  Feelin" src="https://github.com/user-attachments/assets/8ccd9e9d-f0ee-45a2-b915-801b20d9dfe8" />
  <img width="300" alt="Screenshot_20260618_130933_ DEV  Feelin" src="https://github.com/user-attachments/assets/2099577a-5e3e-4562-adea-85170fc26963" />
  <img width="300" alt="Screenshot_20260618_130936_ DEV  Feelin" src="https://github.com/user-attachments/assets/d91d00fe-91ec-4e20-ad38-dcc17fad0da8" />
</p>

#### Dark mode

<p>
  <img width="300" alt="Screenshot_20260618_130916_ DEV  Feelin" src="https://github.com/user-attachments/assets/468a89ca-2739-4e19-b6d0-b6861c9eec86" />
  <img width="300" alt="Screenshot_20260618_130901_ DEV  Feelin" src="https://github.com/user-attachments/assets/8b2bf495-fab8-4fd4-bebc-dc7c062aa138" />
  <img width="300" alt="Screenshot_20260618_130905_ DEV  Feelin" src="https://github.com/user-attachments/assets/1b689e21-25fd-4c5e-9508-8e456f73eae4" />
</p>

### New layout

#### Light mode
<p>
  <img width="300" alt="Screenshot_20260618_131328_ DEV  Feelin" src="https://github.com/user-attachments/assets/aea4f53d-3c47-4ec5-934c-739b08f0e75c" />
</p>

#### Dark mode

<p>
  <img width="300" alt="Screenshot_20260618_131338_ DEV  Feelin" src="https://github.com/user-attachments/assets/87d96ca6-0632-4406-aeb6-1c3029b4e4dd" />
</p>


## Other information:

신규 모드일 경우, 필터칩 내부의 데이터가 구분되지 않아 여러 개의 칩이 동시에 눌려져 있습니다.
메인화면에서 사용하는 필터칩의 디자인이 마이페이지에서 사용하는 것과 같아 같은 컴포넌트로 분류했는데, 이 컴포넌트가 가지고 있어야 하는 데이터의 형태가 아티스트/카테고리 역할에 따라 달라져야 해 컴포넌트를 분리할지 고민중입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New Home screen with banner, “favorite artists” row, and notes feed (with tabs/filters and empty-state messaging)
  * Artist record page accessible from artist profiles
  * Like and bookmark interactions on notes
* **Improvements**
  * Theme-appropriate notification icons across the app bar and home header
  * Artist record screen now shows the selected artist and the back button returns to the previous screen

<!-- end of auto-generated comment: release notes by coderabbit.ai -->