### PR TITLE
SCRUM-282 design: add blocked user management screen

### DIFF
--- a/app/src/androidTest/java/com/lyrics/feelin/presentation/view/mypage/blockedusers/BlockedUsersScreenTest.kt
+++ b/app/src/androidTest/java/com/lyrics/feelin/presentation/view/mypage/blockedusers/BlockedUsersScreenTest.kt
@@ -1,0 +1,57 @@
+package com.lyrics.feelin.presentation.view.mypage.blockedusers
+
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import com.lyrics.feelin.presentation.view.mypage.blockedusers.component.BlockedUserListItem
+import com.lyrics.feelin.presentation.view.mypage.blockedusers.BlockedUserListItemData
+import com.lyrics.feelin.presentation.designsystem.theme.FeelinTheme
+import org.junit.Rule
+import org.junit.Test
+
+class BlockedUsersScreenTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun listItem_showsNicknameAndUnblockButton() {
+        composeRule.setContent {
+            FeelinTheme {
+                BlockedUserListItem(
+                    data = BlockedUserListItemData(
+                        userId = 1L,
+                        nickname = "username01",
+                        profileImageUrl = null,
+                    ),
+                    onUnblockClick = {},
+                )
+            }
+        }
+
+        composeRule.onNodeWithText("username01").assertExists()
+        composeRule.onNodeWithText("차단 해제").assertExists()
+    }
+
+    @Test
+    fun blockedUsersScreen_unblockClick_showsSnackbar() {
+        composeRule.setContent {
+            FeelinTheme {
+                BlockedUsersScreen(
+                    blockedUsers = listOf(
+                        BlockedUserListItemData(
+                            userId = 1L,
+                            nickname = "username01",
+                            profileImageUrl = null,
+                        ),
+                    ),
+                    onBackClick = {},
+                )
+            }
+        }
+
+        composeRule.onNodeWithText("차단 해제").performClick()
+        composeRule.waitForIdle()
+
+        composeRule.onNodeWithText("차단 해제되었습니다").assertExists()
+    }
+}

--- a/app/src/main/java/com/lyrics/feelin/core/designsystem/component/FeelinActionButton.kt
+++ b/app/src/main/java/com/lyrics/feelin/core/designsystem/component/FeelinActionButton.kt
@@ -1,0 +1,46 @@
+package com.lyrics.feelin.core.designsystem.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.unit.dp
+import com.lyrics.feelin.presentation.designsystem.theme.FeelinTypography
+import com.lyrics.feelin.presentation.designsystem.theme.LocalFeelinColors
+
+/**
+ * 정보형 설정 항목의 trailing 영역에 들어가는 소형 액션 버튼에 기반한 컴포넌트입니다.
+ * (Figma component name Button_Copy)
+ */
+@Composable
+fun FeelinActionButton(
+    text: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val feelinColors = LocalFeelinColors.current
+
+    Box(
+        modifier = modifier
+            .width(68.dp)
+            .height(28.dp)
+            .clip(RoundedCornerShape(4.dp))
+            .background(color = feelinColors.brandSecondary)
+            .clickable(onClick = onClick)
+            .padding(horizontal = 8.dp, vertical = 4.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = text,
+            style = FeelinTypography.body2.copy(color = feelinColors.brandPrimary),
+        )
+    }
+}

--- a/app/src/main/java/com/lyrics/feelin/core/designsystem/component/FeelinSnackbar.kt
+++ b/app/src/main/java/com/lyrics/feelin/core/designsystem/component/FeelinSnackbar.kt
@@ -1,0 +1,116 @@
+package com.lyrics.feelin.core.designsystem.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material3.Icon
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.lyrics.feelin.presentation.designsystem.theme.FeelinTheme
+import com.lyrics.feelin.presentation.designsystem.theme.FeelinTypography
+import com.lyrics.feelin.presentation.designsystem.theme.LocalDarkTheme
+import com.lyrics.feelin.presentation.designsystem.theme.LocalFeelinColors
+
+@Composable
+fun FeelinSnackbarHost(
+    hostState: SnackbarHostState,
+    modifier: Modifier = Modifier
+) {
+    SnackbarHost(
+        hostState = hostState,
+        modifier = modifier.padding(horizontal = 20.dp),
+        snackbar = { snackbarData ->
+            FeelinSnackbar(
+                message = snackbarData.visuals.message
+            )
+        }
+    )
+}
+
+@Composable
+fun FeelinSnackbar(
+    message: String,
+    modifier: Modifier = Modifier
+) {
+    val isDark = LocalDarkTheme.current
+    val backgroundColor = if (isDark) {
+        LocalFeelinColors.current.backgroundSecondary
+    } else {
+        LocalFeelinColors.current.gray07
+    }
+
+    val textColor = if (isDark) {
+        LocalFeelinColors.current.gray09
+    } else {
+        Color.White
+    }
+
+    Surface(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(56.dp)
+            .shadow(
+                elevation = 10.dp,
+                shape = RoundedCornerShape(8.dp),
+                ambientColor = Color.Black.copy(alpha = 0.15f),
+                spotColor = Color.Black.copy(alpha = 0.15f)
+            ),
+        shape = RoundedCornerShape(8.dp),
+        color = backgroundColor
+    ) {
+        Row(
+            modifier = Modifier.padding(start = 18.dp, top = 16.dp, bottom = 16.dp, end = 16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Icon(
+                imageVector = Icons.Filled.CheckCircle,
+                contentDescription = null,
+                tint = LocalFeelinColors.current.brandPrimary,
+                modifier = Modifier.size(24.dp)
+            )
+            Text(
+                text = message,
+                style = FeelinTypography.body2,
+                color = textColor
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun FeelinSnackbarLightPreview() {
+    FeelinTheme(darkTheme = false) {
+        FeelinSnackbar(
+            message = "차단 해제되었습니다",
+            modifier = Modifier.padding(20.dp)
+        )
+    }
+}
+
+@Preview(showBackground = true, backgroundColor = 0xFF000000)
+@Composable
+private fun FeelinSnackbarDarkPreview() {
+    FeelinTheme(darkTheme = true) {
+        FeelinSnackbar(
+            message = "차단 해제되었습니다",
+            modifier = Modifier.padding(20.dp)
+        )
+    }
+}

--- a/app/src/main/java/com/lyrics/feelin/navigation/FeelinDestination.kt
+++ b/app/src/main/java/com/lyrics/feelin/navigation/FeelinDestination.kt
@@ -72,6 +72,7 @@ sealed class FeelinDestination(
     object MyPage : FeelinDestination(route = "my_page")
     object Setting : FeelinDestination(route = "setting")
     object UserInfo : FeelinDestination(route = "user_info")
+    object BlockedUsers : FeelinDestination(route = "blocked_users")
 
     object InternalWebView : FeelinDestination(
         route = "internal_webview?$WEB_VIEW_URL_ARGUMENT={$WEB_VIEW_URL_ARGUMENT}"

--- a/app/src/main/java/com/lyrics/feelin/navigation/FeelinNavHost.kt
+++ b/app/src/main/java/com/lyrics/feelin/navigation/FeelinNavHost.kt
@@ -420,6 +420,7 @@ private fun NavGraphBuilder.myPageNavGraph(navController: NavHostController) {
             MainScaffold(navController = navController, selectedIndex = 2) {
                 BlockedUsersScreen(
                     blockedUsers = uiState.blockedUsers,
+                    onUnblockClick = viewModel::unblockUser,
                     onBackClick = { navController.popBackStack() }
                 )
             }

--- a/app/src/main/java/com/lyrics/feelin/navigation/FeelinNavHost.kt
+++ b/app/src/main/java/com/lyrics/feelin/navigation/FeelinNavHost.kt
@@ -54,6 +54,8 @@ import com.lyrics.feelin.presentation.view.login.LoginScreen
 import com.lyrics.feelin.presentation.view.mypage.MyPageLogoutStatus
 import com.lyrics.feelin.presentation.view.mypage.MyPageScreen
 import com.lyrics.feelin.presentation.view.mypage.MyPageViewModel
+import com.lyrics.feelin.presentation.view.mypage.blockedusers.BlockedUserListItemData
+import com.lyrics.feelin.presentation.view.mypage.blockedusers.BlockedUsersScreen
 import com.lyrics.feelin.presentation.view.mypage.setting.SettingScreen
 import com.lyrics.feelin.presentation.view.mypage.userinfo.UserInfoScreen
 import com.lyrics.feelin.presentation.view.note.detail.NoteDetailScreen
@@ -345,6 +347,7 @@ private fun NavGraphBuilder.mainNavGraph(navController: NavHostController) {
     }
 }
 
+@Suppress("LongMethod")
 private fun NavGraphBuilder.myPageNavGraph(navController: NavHostController) {
     navigation(startDestination = FeelinDestination.MyPage.route, route = FeelinDestination.MyPageGraph.route) {
         composable(FeelinDestination.MyPage.route) { backStackEntry ->
@@ -389,6 +392,7 @@ private fun NavGraphBuilder.myPageNavGraph(navController: NavHostController) {
                 SettingScreen(
                     onBackClick = { navController.popBackStack() },
                     onUserInfoClick = { navController.navigate(FeelinDestination.UserInfo.route) },
+                    onBlockedUsersClick = { navController.navigate(FeelinDestination.BlockedUsers.route) },
                     onLogoutClick = viewModel::logout,
                     onInternalWebViewClick = { url ->
                         navController.navigate(FeelinDestination.InternalWebView.createRoute(url))
@@ -403,6 +407,21 @@ private fun NavGraphBuilder.myPageNavGraph(navController: NavHostController) {
         composable(FeelinDestination.UserInfo.route) {
             MainScaffold(navController = navController, selectedIndex = 2) {
                 UserInfoScreen(onBackClick = { navController.popBackStack() })
+            }
+        }
+
+        composable(FeelinDestination.BlockedUsers.route) {
+            val blockedUsersMockData = listOf(
+                BlockedUserListItemData(userId = 1, nickname = "username01", profileImageUrl = null),
+                BlockedUserListItemData(userId = 2, nickname = "username02", profileImageUrl = null),
+                BlockedUserListItemData(userId = 3, nickname = "username03", profileImageUrl = null),
+            )
+
+            MainScaffold(navController = navController, selectedIndex = 2) {
+                BlockedUsersScreen(
+                    blockedUsers = blockedUsersMockData,
+                    onBackClick = { navController.popBackStack() }
+                )
             }
         }
     }

--- a/app/src/main/java/com/lyrics/feelin/navigation/FeelinNavHost.kt
+++ b/app/src/main/java/com/lyrics/feelin/navigation/FeelinNavHost.kt
@@ -54,8 +54,8 @@ import com.lyrics.feelin.presentation.view.login.LoginScreen
 import com.lyrics.feelin.presentation.view.mypage.MyPageLogoutStatus
 import com.lyrics.feelin.presentation.view.mypage.MyPageScreen
 import com.lyrics.feelin.presentation.view.mypage.MyPageViewModel
-import com.lyrics.feelin.presentation.view.mypage.blockedusers.BlockedUserListItemData
 import com.lyrics.feelin.presentation.view.mypage.blockedusers.BlockedUsersScreen
+import com.lyrics.feelin.presentation.view.mypage.blockedusers.BlockedUsersViewModel
 import com.lyrics.feelin.presentation.view.mypage.setting.SettingScreen
 import com.lyrics.feelin.presentation.view.mypage.userinfo.UserInfoScreen
 import com.lyrics.feelin.presentation.view.note.detail.NoteDetailScreen
@@ -410,16 +410,16 @@ private fun NavGraphBuilder.myPageNavGraph(navController: NavHostController) {
             }
         }
 
-        composable(FeelinDestination.BlockedUsers.route) {
-            val blockedUsersMockData = listOf(
-                BlockedUserListItemData(userId = 1, nickname = "username01", profileImageUrl = null),
-                BlockedUserListItemData(userId = 2, nickname = "username02", profileImageUrl = null),
-                BlockedUserListItemData(userId = 3, nickname = "username03", profileImageUrl = null),
-            )
+        composable(FeelinDestination.BlockedUsers.route) { backStackEntry ->
+            val parentEntry = remember(backStackEntry) {
+                navController.getBackStackEntry(FeelinDestination.MyPageGraph.route)
+            }
+            val viewModel: BlockedUsersViewModel = hiltViewModel(parentEntry)
+            val uiState by viewModel.uiState.collectAsState()
 
             MainScaffold(navController = navController, selectedIndex = 2) {
                 BlockedUsersScreen(
-                    blockedUsers = blockedUsersMockData,
+                    blockedUsers = uiState.blockedUsers,
                     onBackClick = { navController.popBackStack() }
                 )
             }

--- a/app/src/main/java/com/lyrics/feelin/presentation/view/mypage/blockedusers/BlockedUserListItemData.kt
+++ b/app/src/main/java/com/lyrics/feelin/presentation/view/mypage/blockedusers/BlockedUserListItemData.kt
@@ -1,0 +1,7 @@
+package com.lyrics.feelin.presentation.view.mypage.blockedusers
+
+data class BlockedUserListItemData(
+    val userId: Long,
+    val nickname: String,
+    val profileImageUrl: String?
+)

--- a/app/src/main/java/com/lyrics/feelin/presentation/view/mypage/blockedusers/BlockedUsersScreen.kt
+++ b/app/src/main/java/com/lyrics/feelin/presentation/view/mypage/blockedusers/BlockedUsersScreen.kt
@@ -37,8 +37,9 @@ private val previewBlockedUsers = listOf(
 @Composable
 fun BlockedUsersScreen(
     blockedUsers: List<BlockedUserListItemData>,
-    onBackClick: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    onUnblockClick: (Long) -> Unit = {},
+    onBackClick: () -> Unit = {},
 ) {
     val colors = LocalFeelinColors.current
     // TODO(@이대근): 3버튼 표시시 하단바와 스낵바가 겹침, 추후 전역 스낵바 도입 및 이를 제거 2026.07.07.
@@ -88,6 +89,7 @@ fun BlockedUsersScreen(
                     BlockedUserListItem(
                         data = user,
                         onUnblockClick = {
+                            onUnblockClick(user.userId)
                             coroutineScope.launch {
                                 snackbarHostState.showSnackbar(message = "차단 해제되었습니다")
                             }

--- a/app/src/main/java/com/lyrics/feelin/presentation/view/mypage/blockedusers/BlockedUsersScreen.kt
+++ b/app/src/main/java/com/lyrics/feelin/presentation/view/mypage/blockedusers/BlockedUsersScreen.kt
@@ -41,6 +41,7 @@ fun BlockedUsersScreen(
     modifier: Modifier = Modifier
 ) {
     val colors = LocalFeelinColors.current
+    // TODO(@이대근): 3버튼 표시시 하단바와 스낵바가 겹침, 추후 전역 스낵바 도입 및 이를 제거 2026.07.07.
     val snackbarHostState = remember { SnackbarHostState() }
     val coroutineScope = rememberCoroutineScope()
 

--- a/app/src/main/java/com/lyrics/feelin/presentation/view/mypage/blockedusers/BlockedUsersScreen.kt
+++ b/app/src/main/java/com/lyrics/feelin/presentation/view/mypage/blockedusers/BlockedUsersScreen.kt
@@ -1,0 +1,150 @@
+package com.lyrics.feelin.presentation.view.mypage.blockedusers
+
+import android.content.res.Configuration
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import com.lyrics.feelin.core.designsystem.component.FeelinSnackbarHost
+import com.lyrics.feelin.core.designsystem.component.FeelinTopAppBarWithBack
+import com.lyrics.feelin.presentation.designsystem.theme.FeelinTheme
+import com.lyrics.feelin.presentation.designsystem.theme.FeelinTypography
+import com.lyrics.feelin.presentation.designsystem.theme.LocalFeelinColors
+import com.lyrics.feelin.presentation.view.mypage.blockedusers.component.BlockedUserListItem
+import kotlinx.coroutines.launch
+
+@Composable
+fun BlockedUsersScreen(
+    blockedUsers: List<BlockedUserListItemData>,
+    onBackClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val colors = LocalFeelinColors.current
+    val snackbarHostState = remember { SnackbarHostState() }
+    val coroutineScope = rememberCoroutineScope()
+
+    Scaffold(
+        modifier = modifier.fillMaxSize(),
+        topBar = {
+            FeelinTopAppBarWithBack(
+                title = "차단된 유저 관리",
+                onBackClick = onBackClick
+            )
+        },
+        snackbarHost = {
+            FeelinSnackbarHost(hostState = snackbarHostState)
+        },
+        containerColor = colors.backgroundPrimary
+    ) { paddingValues ->
+        if (blockedUsers.isEmpty()) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(paddingValues),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(
+                    text = "차단된 유저가 없어요",
+                    style = FeelinTypography.body2,
+                    color = colors.gray04
+                )
+            }
+        } else {
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(paddingValues)
+                    .background(colors.backgroundPrimary)
+            ) {
+                items(
+                    items = blockedUsers,
+                    key = { it.userId }
+                ) { user ->
+                    BlockedUserListItem(
+                        data = user,
+                        onUnblockClick = {
+                            coroutineScope.launch {
+                                snackbarHostState.showSnackbar(message = "차단 해제되었습니다")
+                            }
+                        }
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun BlockedUsersScreenPreviewListLight() {
+    FeelinTheme {
+        BlockedUsersScreen(
+            blockedUsers = listOf(
+                BlockedUserListItemData(1L, "차단된 사용자 닉네임", null),
+                BlockedUserListItemData(2L, "차단된 사용자 닉네임 2", null)
+            ),
+            onBackClick = {}
+        )
+    }
+}
+
+@Preview(showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+private fun BlockedUsersScreenPreviewListDark() {
+    FeelinTheme {
+        BlockedUsersScreen(
+            blockedUsers = listOf(
+                BlockedUserListItemData(1L, "차단된 사용자 닉네임", null),
+                BlockedUserListItemData(2L, "차단된 사용자 닉네임 2", null)
+            ),
+            onBackClick = {}
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun BlockedUsersScreenPreviewEmptyLight() {
+    FeelinTheme {
+        BlockedUsersScreen(
+            blockedUsers = emptyList(),
+            onBackClick = {}
+        )
+    }
+}
+
+@Preview(showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+private fun BlockedUsersScreenPreviewEmptyDark() {
+    FeelinTheme {
+        BlockedUsersScreen(
+            blockedUsers = emptyList(),
+            onBackClick = {}
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun BlockedUsersScreenPreviewSnackbarInteractive() {
+    // Note: To see the snackbar in Preview, run it in Interactive Mode and click '차단 해제'
+    FeelinTheme {
+        BlockedUsersScreen(
+            blockedUsers = listOf(
+                BlockedUserListItemData(1L, "인터랙티브 모드에서 차단 해제 클릭", null)
+            ),
+            onBackClick = {}
+        )
+    }
+}

--- a/app/src/main/java/com/lyrics/feelin/presentation/view/mypage/blockedusers/BlockedUsersScreen.kt
+++ b/app/src/main/java/com/lyrics/feelin/presentation/view/mypage/blockedusers/BlockedUsersScreen.kt
@@ -24,6 +24,11 @@ import com.lyrics.feelin.presentation.designsystem.theme.LocalFeelinColors
 import com.lyrics.feelin.presentation.view.mypage.blockedusers.component.BlockedUserListItem
 import kotlinx.coroutines.launch
 
+private val previewBlockedUsers = listOf(
+    BlockedUserListItemData(1L, "차단된 사용자 닉네임", null),
+    BlockedUserListItemData(2L, "차단된 사용자 닉네임 2", null)
+)
+
 @Composable
 fun BlockedUsersScreen(
     blockedUsers: List<BlockedUserListItemData>,
@@ -90,10 +95,7 @@ fun BlockedUsersScreen(
 private fun BlockedUsersScreenPreviewListLight() {
     FeelinTheme {
         BlockedUsersScreen(
-            blockedUsers = listOf(
-                BlockedUserListItemData(1L, "차단된 사용자 닉네임", null),
-                BlockedUserListItemData(2L, "차단된 사용자 닉네임 2", null)
-            ),
+            blockedUsers = previewBlockedUsers,
             onBackClick = {}
         )
     }
@@ -104,10 +106,7 @@ private fun BlockedUsersScreenPreviewListLight() {
 private fun BlockedUsersScreenPreviewListDark() {
     FeelinTheme {
         BlockedUsersScreen(
-            blockedUsers = listOf(
-                BlockedUserListItemData(1L, "차단된 사용자 닉네임", null),
-                BlockedUserListItemData(2L, "차단된 사용자 닉네임 2", null)
-            ),
+            blockedUsers = previewBlockedUsers,
             onBackClick = {}
         )
     }

--- a/app/src/main/java/com/lyrics/feelin/presentation/view/mypage/blockedusers/BlockedUsersScreen.kt
+++ b/app/src/main/java/com/lyrics/feelin/presentation/view/mypage/blockedusers/BlockedUsersScreen.kt
@@ -3,8 +3,13 @@ package com.lyrics.feelin.presentation.view.mypage.blockedusers
 import android.content.res.Configuration
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Scaffold
@@ -40,7 +45,10 @@ fun BlockedUsersScreen(
     val coroutineScope = rememberCoroutineScope()
 
     Scaffold(
-        modifier = modifier.fillMaxSize(),
+        modifier = modifier
+            .fillMaxSize()
+            .windowInsetsPadding(WindowInsets.systemBars.only(WindowInsetsSides.Top))
+            .background(colors.backgroundPrimary),
         topBar = {
             FeelinTopAppBarWithBack(
                 title = "차단된 유저 관리",

--- a/app/src/main/java/com/lyrics/feelin/presentation/view/mypage/blockedusers/BlockedUsersUiState.kt
+++ b/app/src/main/java/com/lyrics/feelin/presentation/view/mypage/blockedusers/BlockedUsersUiState.kt
@@ -1,0 +1,9 @@
+package com.lyrics.feelin.presentation.view.mypage.blockedusers
+
+data class BlockedUsersUiState(
+    val blockedUsers: List<BlockedUserListItemData> = emptyList()
+) {
+    companion object {
+        fun initial(): BlockedUsersUiState = BlockedUsersUiState()
+    }
+}

--- a/app/src/main/java/com/lyrics/feelin/presentation/view/mypage/blockedusers/BlockedUsersViewModel.kt
+++ b/app/src/main/java/com/lyrics/feelin/presentation/view/mypage/blockedusers/BlockedUsersViewModel.kt
@@ -1,0 +1,22 @@
+package com.lyrics.feelin.presentation.view.mypage.blockedusers
+
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+@HiltViewModel
+class BlockedUsersViewModel @Inject constructor() : ViewModel() {
+    private val _uiState: MutableStateFlow<BlockedUsersUiState> = MutableStateFlow(
+        BlockedUsersUiState(
+            blockedUsers = listOf(
+                BlockedUserListItemData(userId = 1, nickname = "username01", profileImageUrl = null),
+                BlockedUserListItemData(userId = 2, nickname = "username02", profileImageUrl = null),
+                BlockedUserListItemData(userId = 3, nickname = "username03", profileImageUrl = null),
+            )
+        )
+    )
+    val uiState: StateFlow<BlockedUsersUiState> = _uiState.asStateFlow()
+}

--- a/app/src/main/java/com/lyrics/feelin/presentation/view/mypage/blockedusers/BlockedUsersViewModel.kt
+++ b/app/src/main/java/com/lyrics/feelin/presentation/view/mypage/blockedusers/BlockedUsersViewModel.kt
@@ -19,4 +19,10 @@ class BlockedUsersViewModel @Inject constructor() : ViewModel() {
         )
     )
     val uiState: StateFlow<BlockedUsersUiState> = _uiState.asStateFlow()
+
+    fun unblockUser(userId: Long) {
+        _uiState.value = _uiState.value.copy(
+            blockedUsers = _uiState.value.blockedUsers.filter { it.userId != userId }
+        )
+    }
 }

--- a/app/src/main/java/com/lyrics/feelin/presentation/view/mypage/blockedusers/component/BlockedUserListItem.kt
+++ b/app/src/main/java/com/lyrics/feelin/presentation/view/mypage/blockedusers/component/BlockedUserListItem.kt
@@ -1,0 +1,112 @@
+package com.lyrics.feelin.presentation.view.mypage.blockedusers.component
+
+import android.content.res.Configuration
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import coil3.compose.AsyncImage
+import com.lyrics.feelin.core.designsystem.component.FeelinActionButton
+import com.lyrics.feelin.presentation.designsystem.theme.FeelinTheme
+import com.lyrics.feelin.presentation.designsystem.theme.FeelinTypography
+import com.lyrics.feelin.presentation.designsystem.theme.LocalFeelinColors
+import com.lyrics.feelin.presentation.view.mypage.blockedusers.BlockedUserListItemData
+
+@Composable
+fun BlockedUserListItem(
+    data: BlockedUserListItemData,
+    onUnblockClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val colors = LocalFeelinColors.current
+
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .background(colors.backgroundPrimary)
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(72.dp)
+                .padding(horizontal = 20.dp, vertical = 16.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            AsyncImage(
+                model = data.profileImageUrl,
+                contentDescription = "Profile Image",
+                modifier = Modifier
+                    .size(40.dp)
+                    .clip(CircleShape)
+                    .background(colors.backgroundTertiary),
+                contentScale = ContentScale.Crop
+            )
+
+            Spacer(modifier = Modifier.width(8.dp))
+
+            Text(
+                text = data.nickname,
+                style = FeelinTypography.title2.copy(color = colors.gray09),
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.weight(1f)
+            )
+
+            Spacer(modifier = Modifier.width(8.dp))
+
+            FeelinActionButton(text = "차단 해제", onClick = onUnblockClick)
+        }
+
+        HorizontalDivider(
+            modifier = Modifier.fillMaxWidth(),
+            thickness = 1.dp,
+            color = colors.backgroundTertiary
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun BlockedUserListItemPreviewLight() {
+    FeelinTheme {
+        BlockedUserListItem(
+            data = BlockedUserListItemData(
+                userId = 1L,
+                nickname = "차단된 사용자 닉네임",
+                profileImageUrl = null
+            ),
+            onUnblockClick = {}
+        )
+    }
+}
+
+@Preview(showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+private fun BlockedUserListItemPreviewDark() {
+    FeelinTheme {
+        BlockedUserListItem(
+            data = BlockedUserListItemData(
+                userId = 1L,
+                nickname = "차단된 사용자 닉네임",
+                profileImageUrl = null
+            ),
+            onUnblockClick = {}
+        )
+    }
+}

--- a/app/src/main/java/com/lyrics/feelin/presentation/view/mypage/blockedusers/component/BlockedUserListItem.kt
+++ b/app/src/main/java/com/lyrics/feelin/presentation/view/mypage/blockedusers/component/BlockedUserListItem.kt
@@ -22,17 +22,17 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
-import com.lyrics.feelin.core.designsystem.component.FeelinActionButton
 import com.lyrics.feelin.presentation.designsystem.theme.FeelinTheme
 import com.lyrics.feelin.presentation.designsystem.theme.FeelinTypography
 import com.lyrics.feelin.presentation.designsystem.theme.LocalFeelinColors
 import com.lyrics.feelin.presentation.view.mypage.blockedusers.BlockedUserListItemData
+import com.lyrics.feelin.presentation.view.mypage.component.FeelinActionButton
 
 @Composable
 fun BlockedUserListItem(
     data: BlockedUserListItemData,
-    onUnblockClick: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    onUnblockClick: () -> Unit = {},
 ) {
     val colors = LocalFeelinColors.current
 

--- a/app/src/main/java/com/lyrics/feelin/presentation/view/mypage/component/FeelinActionButton.kt
+++ b/app/src/main/java/com/lyrics/feelin/presentation/view/mypage/component/FeelinActionButton.kt
@@ -1,4 +1,4 @@
-package com.lyrics.feelin.core.designsystem.component
+package com.lyrics.feelin.presentation.view.mypage.component
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable

--- a/app/src/main/java/com/lyrics/feelin/presentation/view/mypage/component/SettingInfoItem.kt
+++ b/app/src/main/java/com/lyrics/feelin/presentation/view/mypage/component/SettingInfoItem.kt
@@ -1,20 +1,12 @@
 package com.lyrics.feelin.presentation.view.mypage.component
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.RowScope
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.unit.dp
 import com.lyrics.feelin.presentation.designsystem.theme.FeelinTypography
 import com.lyrics.feelin.presentation.designsystem.theme.LocalFeelinColors
 
@@ -73,31 +65,4 @@ fun SettingInfoItem(
             )
         },
     )
-}
-
-/**
- * 정보형 설정 항목의 trailing 영역에 들어가는 소형 액션 버튼입니다.
- */
-@Composable
-fun SettingInfoActionButton(
-    text: String,
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    val feelinColors = LocalFeelinColors.current
-
-    Box(
-        modifier = modifier
-            .height(28.dp)
-            .clip(shape = RoundedCornerShape(4.dp))
-            .background(color = feelinColors.brandSecondary)
-            .clickable(onClick = onClick)
-            .padding(horizontal = 8.dp, vertical = 4.dp),
-        contentAlignment = Alignment.Center,
-    ) {
-        Text(
-            text = text,
-            style = FeelinTypography.body2.copy(color = feelinColors.brandPrimary),
-        )
-    }
 }

--- a/app/src/main/java/com/lyrics/feelin/presentation/view/mypage/setting/SettingScreen.kt
+++ b/app/src/main/java/com/lyrics/feelin/presentation/view/mypage/setting/SettingScreen.kt
@@ -38,6 +38,7 @@ import com.lyrics.feelin.presentation.view.mypage.component.SettingMenuItem
 fun SettingScreen(
     onBackClick: () -> Unit,
     onUserInfoClick: () -> Unit,
+    onBlockedUsersClick: () -> Unit,
     onLogoutClick: () -> Unit,
     onInternalWebViewClick: (String) -> Unit,
     onExternalBrowserClick: (String) -> Unit,
@@ -84,6 +85,8 @@ fun SettingScreen(
                 Spacer(modifier = Modifier.height(40.dp))
 
                 SettingMenuItem(title = "회원 정보", onClick = onUserInfoClick)
+                Spacer(modifier = Modifier.height(16.dp))
+                SettingMenuItem(title = "차단된 유저 관리", onClick = onBlockedUsersClick)
 
                 SettingCategoryDivider()
 
@@ -152,6 +155,7 @@ private fun SettingScreenPreview() {
         SettingScreen(
             onBackClick = {},
             onUserInfoClick = {},
+            onBlockedUsersClick = {},
             onLogoutClick = {},
             onInternalWebViewClick = {},
             onExternalBrowserClick = {},

--- a/app/src/main/java/com/lyrics/feelin/presentation/view/mypage/userinfo/UserInfoScreen.kt
+++ b/app/src/main/java/com/lyrics/feelin/presentation/view/mypage/userinfo/UserInfoScreen.kt
@@ -21,12 +21,12 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.lyrics.feelin.core.designsystem.component.FeelinActionButton
 import com.lyrics.feelin.core.designsystem.component.FeelinTopAppBarWithBack
 import com.lyrics.feelin.presentation.designsystem.theme.FeelinTheme
 import com.lyrics.feelin.presentation.designsystem.theme.FeelinTypography
 import com.lyrics.feelin.presentation.designsystem.theme.LocalFeelinColors
 import com.lyrics.feelin.presentation.view.mypage.component.LoginInfoConfigs
-import com.lyrics.feelin.presentation.view.mypage.component.SettingInfoActionButton
 import com.lyrics.feelin.presentation.view.mypage.component.SettingInfoItem
 import com.lyrics.feelin.presentation.view.mypage.component.SettingMenuItem
 import com.lyrics.feelin.presentation.view.mypage.component.UserLoginInfoItem
@@ -71,7 +71,7 @@ fun UserInfoScreen(
             SettingInfoItem(
                 title = uid,
                 trailingContent = {
-                    SettingInfoActionButton(text = "복사", onClick = { /* TODO: UID 복사기능 및 스낵바 표시 */ })
+                    FeelinActionButton(text = "복사", onClick = { /* TODO: UID 복사기능 및 스낵바 표시 */ })
                 },
             )
 

--- a/app/src/main/java/com/lyrics/feelin/presentation/view/mypage/userinfo/UserInfoScreen.kt
+++ b/app/src/main/java/com/lyrics/feelin/presentation/view/mypage/userinfo/UserInfoScreen.kt
@@ -21,11 +21,11 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.lyrics.feelin.core.designsystem.component.FeelinActionButton
 import com.lyrics.feelin.core.designsystem.component.FeelinTopAppBarWithBack
 import com.lyrics.feelin.presentation.designsystem.theme.FeelinTheme
 import com.lyrics.feelin.presentation.designsystem.theme.FeelinTypography
 import com.lyrics.feelin.presentation.designsystem.theme.LocalFeelinColors
+import com.lyrics.feelin.presentation.view.mypage.component.FeelinActionButton
 import com.lyrics.feelin.presentation.view.mypage.component.LoginInfoConfigs
 import com.lyrics.feelin.presentation.view.mypage.component.SettingInfoItem
 import com.lyrics.feelin.presentation.view.mypage.component.SettingMenuItem


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our guidelines


## What kind of change does this PR introduce?

- Implement design


# What is the current behavior?

마이페이지 설정 메뉴 내에 차단된 유저를 관리할 수 있는 화면으로의 진입점이 없으며, 관련 기능을 위한 화면 UI가 구현되어 있지 않은 상태입니다.


# What is the new behavior (if this is a feature change)?

차단된 유저 목록을 확인하고 관리할 수 있는 화면을 신규 구현했습니다.
- 서버 연동 없이 목업 데이터를 사용하는 레이아웃 중심의 구현입니다.
- 마이페이지 설정 메뉴에 '차단된 유저 관리' 메뉴 항목을 추가하여 화면 진입을 연결했습니다.
- 상단 앱바, 유저 리스트, 유저가 없을 때의 빈 화면 상태, 동작 피드백을 위한 스낵바를 포함합니다.
- 공통 컴포넌트로 `FeelinActionButton`과 `FeelinSnackbar`를 신규 구현하거나 추출하여 적용했습니다.

## Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

없음.

## ScreenShots (If needed)

### Light mode

<p>
  <img width="200" alt="Screenshot_20260707_004320_ DEV  Feelin" src="https://github.com/user-attachments/assets/f4f8bc9a-7ab1-48fb-8cb4-3e11add12a3e" />
  <img width="200" alt="Screenshot_20260707_004322_ DEV  Feelin" src="https://github.com/user-attachments/assets/ac8271ec-16c7-427a-b380-50367a107221" />
  <img width="200" alt="Screenshot_20260708_195047" src="https://github.com/user-attachments/assets/8cfd4cb3-3e55-47c0-a44f-c8a309cc3cd9" />
</p>

### Dark mode

<p>
  <img width="200" alt="Screenshot_20260707_004336_ DEV  Feelin" src="https://github.com/user-attachments/assets/ffd20103-80ee-4805-973f-c95369debfb7" />
  <img width="200" alt="Screenshot_20260707_004351_ DEV  Feelin" src="https://github.com/user-attachments/assets/03d066f9-96e9-44b0-a36e-8a9ec3c9d4b5" />
  <img width="200"alt="Screenshot_20260708_195031" src="https://github.com/user-attachments/assets/8c49c8b7-7b0a-450e-89d7-8b18bec28d17" />
</p>


## Other information:

### AI Agent
- `./gradlew detekt` 및 `./gradlew :app:assembleDebug` 명령을 통해 코드 품질 및 빌드 정상 여부를 확인했습니다.
- 주요 변경 사항 요약:
  - `BlockedUsersScreen.kt`: 차단 목록 UI 및 화면 상태 분기 처리.
  - `BlockedUsersViewModel.kt`: UI 상태 및 목업 데이터 관리.
  - `FeelinActionButton.kt`: 여러 화면에서 공통으로 사용할 수 있도록 추출한 버튼 컴포넌트.
  - `FeelinSnackbar.kt`: 커스텀 디자인이 적용된 신규 공통 스낵바.
  - `FeelinNavHost.kt`, `FeelinDestination.kt`: 남비게이션 경로 정의 및 마이페이지 그래프 연결.
  - `BlockedUsersScreenTest.kt`: 리스트 아이템 및 스낵바 노출 여부에 대한 UI 테스트 추가.

### User
이번에 추가한 스낵바가 시스템 내비바가 3버튼으로 표시될 경우에 앱 하단바와 겹쳐 표시되는 문제가 있습니다. 추후 스낵바를 전역으로 표시하는 등의 조치를 통해 이를 수정하겠습니다.