### PR TITLE
SCRUM-300 design: Add note report flow screen

### DIFF
--- a/app/src/androidTest/java/com/lyrics/feelin/presentation/view/note/report/NoteReportScreenTest.kt
+++ b/app/src/androidTest/java/com/lyrics/feelin/presentation/view/note/report/NoteReportScreenTest.kt
@@ -1,0 +1,73 @@
+package com.lyrics.feelin.presentation.view.note.report
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotSelected
+import androidx.compose.ui.test.assertIsSelected
+import androidx.compose.ui.test.hasClickAction
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.platform.app.InstrumentationRegistry
+import com.lyrics.feelin.presentation.designsystem.theme.FeelinTheme
+import org.junit.Rule
+import org.junit.Test
+
+class NoteReportScreenTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun defaultScreenShowsFigmaContent() {
+        setContent()
+
+        composeTestRule.onNodeWithText("신고사유").assertIsDisplayed()
+        composeTestRule.onNodeWithText("커뮤니티 성격에 맞지 않음").assertIsNotSelected()
+        composeTestRule.onNodeWithText("기타").assertIsDisplayed()
+        captureScreen("note-report-default.png")
+    }
+
+    @Test
+    fun selectingOtherShowsSelectedStateAndInput() {
+        setContent()
+
+        composeTestRule.onNodeWithText("기타").performClick()
+
+        composeTestRule.onNodeWithText("기타").assertIsSelected()
+        composeTestRule.onNodeWithContentDescription("선택됨").assertIsDisplayed()
+        composeTestRule.onNodeWithText("신고사유를 작성해주세요.").assertIsDisplayed()
+        captureScreen("note-report-other-selected.png")
+    }
+
+    @Test
+    fun selectingReasonAndAgreementEnablesSubmit() {
+        setContent()
+
+        composeTestRule.onNodeWithText("상업적 광고").performClick()
+        composeTestRule.onNodeWithText("개인정보 수집에 동의합니다.").performClick()
+
+        composeTestRule.onNode(hasText("신고하기") and hasClickAction())
+            .assertIsEnabled()
+            .performClick()
+        composeTestRule.onNodeWithText("신고가 접수되었어요.").assertIsDisplayed()
+    }
+
+    private fun setContent() {
+        composeTestRule.setContent {
+            FeelinTheme {
+                NoteReportScreen(
+                    noteId = 1L,
+                    onBackClick = {},
+                )
+            }
+        }
+    }
+
+    private fun captureScreen(fileName: String) {
+        InstrumentationRegistry.getInstrumentation().uiAutomation
+            .executeShellCommand("screencap -p /sdcard/$fileName")
+            .close()
+    }
+}

--- a/app/src/main/java/com/lyrics/feelin/core/designsystem/component/FeelinModalBottomSheet.kt
+++ b/app/src/main/java/com/lyrics/feelin/core/designsystem/component/FeelinModalBottomSheet.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -52,6 +53,7 @@ fun FeelinModalBottomSheet(
         sheetState = sheetState,
         onDismissRequest = onDismissRequest,
         containerColor = feelinColors.modal,
+        shape = RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp),
         dragHandle = if (showDragHandle) {
             { FeelinDragHandle() }
         } else {
@@ -117,8 +119,9 @@ fun FeelinModalBottomSheetAction(
                 imageVector = icon,
                 contentDescription = text,
                 tint = feelinColors.gray09,
-                modifier = Modifier.padding(end = 12.dp)
+                modifier = Modifier.size(24.dp),
             )
+            Spacer(modifier = Modifier.width(12.dp))
         }
         Text(text = text, style = FeelinTypography.body1.copy(color = feelinColors.gray09))
     }

--- a/app/src/main/java/com/lyrics/feelin/core/designsystem/icon/Icons.kt
+++ b/app/src/main/java/com/lyrics/feelin/core/designsystem/icon/Icons.kt
@@ -136,3 +136,19 @@ val SubmitArrowIcon: ImageVector
 val ImageGalleryIcon: ImageVector
     @Composable
     get() = ImageVector.vectorResource(id = R.drawable.image_gallery)
+
+val ReportIcon: ImageVector
+    @Composable
+    get() = ImageVector.vectorResource(id = R.drawable.report)
+
+val ModifyIcon: ImageVector
+    @Composable
+    get() = ImageVector.vectorResource(id = R.drawable.modify)
+
+val DeleteIcon: ImageVector
+    @Composable
+    get() = ImageVector.vectorResource(id = R.drawable.control_delete)
+
+val ProhibitIcon: ImageVector
+    @Composable
+    get() = ImageVector.vectorResource(id = R.drawable.prohibit)

--- a/app/src/main/java/com/lyrics/feelin/navigation/FeelinDestination.kt
+++ b/app/src/main/java/com/lyrics/feelin/navigation/FeelinDestination.kt
@@ -69,6 +69,13 @@ sealed class FeelinDestination(
             return "$NOTE_DETAIL_ROUTE/$noteId"
         }
     }
+    object NoteReport : FeelinDestination(route = "note_report/{$NOTE_ID_ARGUMENT}") {
+        const val NoteIdArgument = NOTE_ID_ARGUMENT
+
+        fun createRoute(noteId: Long): String {
+            return "note_report/$noteId"
+        }
+    }
     object MyPage : FeelinDestination(route = "my_page")
     object Setting : FeelinDestination(route = "setting")
     object UserInfo : FeelinDestination(route = "user_info")

--- a/app/src/main/java/com/lyrics/feelin/navigation/FeelinNavHost.kt
+++ b/app/src/main/java/com/lyrics/feelin/navigation/FeelinNavHost.kt
@@ -59,6 +59,7 @@ import com.lyrics.feelin.presentation.view.mypage.blockedusers.BlockedUsersViewM
 import com.lyrics.feelin.presentation.view.mypage.setting.SettingScreen
 import com.lyrics.feelin.presentation.view.mypage.userinfo.UserInfoScreen
 import com.lyrics.feelin.presentation.view.note.detail.NoteDetailScreen
+import com.lyrics.feelin.presentation.view.note.report.NoteReportScreen
 import com.lyrics.feelin.presentation.view.note.search.NoteSearchScreen
 import com.lyrics.feelin.presentation.view.note.search.result.NoteSearchResultScreen
 import com.lyrics.feelin.presentation.view.onboarding.OnboardingUiState
@@ -293,6 +294,9 @@ private fun NavGraphBuilder.mainNavGraph(navController: NavHostController) {
                         onNoteClick = { noteId ->
                             navController.navigate(FeelinDestination.NoteDetail.createRoute(noteId))
                         },
+                        onNoteReportClick = { noteId ->
+                            navController.navigate(FeelinDestination.NoteReport.createRoute(noteId))
+                        },
                         onNoteAddClick = {
                             navController.navigate(FeelinDestination.NoteFormCreate.route)
                         }
@@ -322,6 +326,9 @@ private fun NavGraphBuilder.mainNavGraph(navController: NavHostController) {
                         onNoteClick = { noteId ->
                             navController.navigate(FeelinDestination.NoteDetail.createRoute(noteId))
                         },
+                        onNoteReportClick = { noteId ->
+                            navController.navigate(FeelinDestination.NoteReport.createRoute(noteId))
+                        },
                     )
                 }
             }
@@ -336,6 +343,23 @@ private fun NavGraphBuilder.mainNavGraph(navController: NavHostController) {
                 ?: return@composable
 
             NoteDetailScreen(
+                noteId = noteId,
+                onBackClick = { navController.popBackStack() },
+                onNoteReportClick = { selectedNoteId ->
+                    navController.navigate(FeelinDestination.NoteReport.createRoute(selectedNoteId))
+                },
+            )
+        }
+
+        composable(
+            route = FeelinDestination.NoteReport.route,
+            arguments = listOf(navArgument(FeelinDestination.NoteReport.NoteIdArgument) { type = NavType.LongType }),
+        ) { backStackEntry ->
+            val noteId = backStackEntry.arguments
+                ?.getLong(FeelinDestination.NoteReport.NoteIdArgument)
+                ?: return@composable
+
+            NoteReportScreen(
                 noteId = noteId,
                 onBackClick = { navController.popBackStack() },
             )
@@ -361,6 +385,9 @@ private fun NavGraphBuilder.myPageNavGraph(navController: NavHostController) {
                     onSettingClick = { navController.navigate(FeelinDestination.Setting.route) },
                     onNoteClick = { noteId ->
                         navController.navigate(FeelinDestination.NoteDetail.createRoute(noteId))
+                    },
+                    onNoteReportClick = { noteId ->
+                        navController.navigate(FeelinDestination.NoteReport.createRoute(noteId))
                     },
                     viewModel = viewModel,
                 )

--- a/app/src/main/java/com/lyrics/feelin/navigation/HomeNavigation.kt
+++ b/app/src/main/java/com/lyrics/feelin/navigation/HomeNavigation.kt
@@ -23,6 +23,9 @@ fun HomeRoute(
         onNoteClick = { noteId ->
             navController.navigate(FeelinDestination.NoteDetail.createRoute(noteId))
         },
+        onNoteReportClick = { noteId ->
+            navController.navigate(FeelinDestination.NoteReport.createRoute(noteId))
+        },
         onNotificationClick = {
             // TODO(@이대근): 추후 알림 화면 라우트 연결 2026.06.17.
             Log.d("HomeRoute", "Notification clicked")

--- a/app/src/main/java/com/lyrics/feelin/presentation/view/community/CommunityMainScreen.kt
+++ b/app/src/main/java/com/lyrics/feelin/presentation/view/community/CommunityMainScreen.kt
@@ -41,7 +41,9 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
@@ -64,6 +66,8 @@ import com.lyrics.feelin.presentation.designsystem.theme.LightGray03
 import com.lyrics.feelin.presentation.designsystem.theme.LightGray09
 import com.lyrics.feelin.presentation.designsystem.theme.LocalFeelinColors
 import com.lyrics.feelin.presentation.view.component.note.NoteComponent
+import com.lyrics.feelin.presentation.view.component.note.NoteComponentData
+import com.lyrics.feelin.presentation.view.component.note.NoteMenuBottomSheet
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -72,11 +76,14 @@ fun CommunityMainScreen(
     onBack: () -> Unit,
     modifier: Modifier = Modifier,
     onNoteClick: (Long) -> Unit = {},
+    onNoteReportClick: (Long) -> Unit = {},
     onNoteAddClick: () -> Unit = {},
+    currentUserId: Long? = null,
     viewModel: CommunityViewModel = viewModel()
 ) {
     val listState = rememberLazyListState()
     val communityViewState by viewModel.viewState.collectAsState()
+    var selectedNoteForMenu by remember { mutableStateOf<NoteComponentData?>(null) }
 
     val feelinColors = LocalFeelinColors.current
 
@@ -293,6 +300,7 @@ fun CommunityMainScreen(
                         NoteComponent(
                             noteData = note,
                             onClick = { onNoteClick(it.id) },
+                            onMenuClick = { selectedNoteForMenu = it },
                         )
                     }
                 }
@@ -308,6 +316,18 @@ fun CommunityMainScreen(
                     )
                 }
             }
+        }
+
+        selectedNoteForMenu?.let { selectedNote ->
+            NoteMenuBottomSheet(
+                noteData = selectedNote,
+                currentUserId = currentUserId,
+                onReportClick = { noteId ->
+                    selectedNoteForMenu = null
+                    onNoteReportClick(noteId)
+                },
+                onDismissRequest = { selectedNoteForMenu = null },
+            )
         }
     }
 }

--- a/app/src/main/java/com/lyrics/feelin/presentation/view/component/note/NoteComponent.kt
+++ b/app/src/main/java/com/lyrics/feelin/presentation/view/component/note/NoteComponent.kt
@@ -46,6 +46,7 @@ fun NoteComponent(
     onClick: ((NoteComponentData) -> Unit)? = null,
     onLikeClick: ((NoteComponentData) -> Unit)? = null,
     onBookmarkClick: ((NoteComponentData) -> Unit)? = null,
+    onMenuClick: ((NoteComponentData) -> Unit)? = null,
 ) {
     val feelinColors = LocalFeelinColors.current
 
@@ -80,7 +81,15 @@ fun NoteComponent(
             Icon(
                 imageVector = MeatballIcon,
                 contentDescription = "${noteData.song.name} menu",
-                modifier = Modifier.size(24.dp),
+                modifier = Modifier
+                    .size(24.dp)
+                    .then(
+                        if (onMenuClick != null) {
+                            Modifier.clickable { onMenuClick(noteData) }
+                        } else {
+                            Modifier
+                        }
+                    ),
                 tint = feelinColors.gray03,
             )
         }

--- a/app/src/main/java/com/lyrics/feelin/presentation/view/component/note/NoteMenuBottomSheet.kt
+++ b/app/src/main/java/com/lyrics/feelin/presentation/view/component/note/NoteMenuBottomSheet.kt
@@ -7,6 +7,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import com.lyrics.feelin.core.designsystem.component.FeelinModalBottomSheet
 import com.lyrics.feelin.core.designsystem.component.FeelinModalBottomSheetAction
+import com.lyrics.feelin.core.designsystem.icon.DeleteIcon
+import com.lyrics.feelin.core.designsystem.icon.ModifyIcon
+import com.lyrics.feelin.core.designsystem.icon.ProhibitIcon
+import com.lyrics.feelin.core.designsystem.icon.ReportIcon
 import com.lyrics.feelin.presentation.designsystem.theme.FeelinTheme
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -32,19 +36,23 @@ fun NoteMenuBottomSheet(
         if (isMyNote) {
             FeelinModalBottomSheetAction(
                 text = "수정하기",
+                icon = ModifyIcon,
                 onClick = { onEditClick(noteData.id) },
             )
             FeelinModalBottomSheetAction(
                 text = "삭제하기",
+                icon = DeleteIcon,
                 onClick = { onDeleteClick(noteData.id) },
             )
         } else {
             FeelinModalBottomSheetAction(
                 text = "신고하기",
+                icon = ReportIcon,
                 onClick = { onReportClick(noteData.id) },
             )
             FeelinModalBottomSheetAction(
                 text = "차단하기",
+                icon = ProhibitIcon,
                 onClick = { onBlockClick(noteData.publisher.id) },
             )
         }

--- a/app/src/main/java/com/lyrics/feelin/presentation/view/component/note/NoteMenuBottomSheet.kt
+++ b/app/src/main/java/com/lyrics/feelin/presentation/view/component/note/NoteMenuBottomSheet.kt
@@ -1,0 +1,75 @@
+package com.lyrics.feelin.presentation.view.component.note
+
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import com.lyrics.feelin.core.designsystem.component.FeelinModalBottomSheet
+import com.lyrics.feelin.core.designsystem.component.FeelinModalBottomSheetAction
+import com.lyrics.feelin.presentation.designsystem.theme.FeelinTheme
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun NoteMenuBottomSheet(
+    noteData: NoteComponentData,
+    onDismissRequest: () -> Unit,
+    modifier: Modifier = Modifier,
+    currentUserId: Long? = null,
+    onReportClick: (Long) -> Unit = {},
+    onEditClick: (Long) -> Unit = {},
+    onDeleteClick: (Long) -> Unit = {},
+    onBlockClick: (Long) -> Unit = {},
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    val isMyNote = currentUserId != null && currentUserId == noteData.publisher.id
+
+    FeelinModalBottomSheet(
+        sheetState = sheetState,
+        onDismissRequest = onDismissRequest,
+        modifier = modifier,
+    ) {
+        if (isMyNote) {
+            FeelinModalBottomSheetAction(
+                text = "수정하기",
+                onClick = { onEditClick(noteData.id) },
+            )
+            FeelinModalBottomSheetAction(
+                text = "삭제하기",
+                onClick = { onDeleteClick(noteData.id) },
+            )
+        } else {
+            FeelinModalBottomSheetAction(
+                text = "신고하기",
+                onClick = { onReportClick(noteData.id) },
+            )
+            FeelinModalBottomSheetAction(
+                text = "차단하기",
+                onClick = { onBlockClick(noteData.publisher.id) },
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun NoteMenuBottomSheetOtherPreview() {
+    FeelinTheme {
+        NoteMenuBottomSheet(
+            noteData = NoteComponentData.sample(),
+            onDismissRequest = {},
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun NoteMenuBottomSheetMinePreview() {
+    FeelinTheme {
+        NoteMenuBottomSheet(
+            noteData = NoteComponentData.sample(),
+            currentUserId = NoteComponentData.sample().publisher.id,
+            onDismissRequest = {},
+        )
+    }
+}

--- a/app/src/main/java/com/lyrics/feelin/presentation/view/home/HomeScreen.kt
+++ b/app/src/main/java/com/lyrics/feelin/presentation/view/home/HomeScreen.kt
@@ -23,6 +23,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.pointer.pointerInput
@@ -33,6 +36,8 @@ import com.lyrics.feelin.core.designsystem.component.FeelinModalDialog
 import com.lyrics.feelin.presentation.designsystem.theme.FeelinTheme
 import com.lyrics.feelin.presentation.designsystem.theme.LocalFeelinColors
 import com.lyrics.feelin.presentation.view.component.artist.ArtistBubbleComponentData
+import com.lyrics.feelin.presentation.view.component.note.NoteComponentData
+import com.lyrics.feelin.presentation.view.component.note.NoteMenuBottomSheet
 import com.lyrics.feelin.presentation.view.home.component.ArtistRow
 import com.lyrics.feelin.presentation.view.home.component.BannerSection
 import com.lyrics.feelin.presentation.view.home.component.DummyBannerSection
@@ -47,11 +52,14 @@ fun HomeScreen(
     onBannerClick: (String) -> Unit,
     onArtistClick: (Long) -> Unit,
     onNoteClick: (Long) -> Unit,
+    onNoteReportClick: (Long) -> Unit,
     onNotificationClick: () -> Unit,
     modifier: Modifier = Modifier,
+    currentUserId: Long? = null,
     viewModel: HomeViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsState()
+    var selectedNoteForMenu by remember { mutableStateOf<NoteComponentData?>(null) }
 
     LaunchedEffect(Unit) {
         viewModel.loadHomeData()
@@ -158,11 +166,24 @@ fun HomeScreen(
                             onFilterClick = viewModel::selectFilter,
                             onNoteClick = onNoteClick,
                             onNoteLikeClick = viewModel::toggleLike,
-                            onNoteBookmarkClick = viewModel::toggleBookmark
+                            onNoteBookmarkClick = viewModel::toggleBookmark,
+                            onNoteMenuClick = { selectedNoteForMenu = it },
                         )
                     }
                 }
             }
+        }
+
+        selectedNoteForMenu?.let { selectedNote ->
+            NoteMenuBottomSheet(
+                noteData = selectedNote,
+                currentUserId = currentUserId,
+                onReportClick = { noteId ->
+                    selectedNoteForMenu = null
+                    onNoteReportClick(noteId)
+                },
+                onDismissRequest = { selectedNoteForMenu = null },
+            )
         }
 
         if (uiState.bottomSheetType == HomeBottomSheetType.MyFavoriteArtists) {
@@ -221,6 +242,7 @@ private fun HomeScreenPreviewLoading() {
             onBannerClick = {},
             onArtistClick = {},
             onNoteClick = {},
+            onNoteReportClick = {},
             onNotificationClick = {},
         )
     }

--- a/app/src/main/java/com/lyrics/feelin/presentation/view/home/component/FeedSection.kt
+++ b/app/src/main/java/com/lyrics/feelin/presentation/view/home/component/FeedSection.kt
@@ -36,6 +36,7 @@ fun LazyListScope.feedSection(
     onNoteClick: (Long) -> Unit = {},
     onNoteLikeClick: (Long) -> Unit = {},
     onNoteBookmarkClick: (Long) -> Unit = {},
+    onNoteMenuClick: (NoteComponentData) -> Unit = {},
 ) {
     feedSectionHeader(
         selectedTab = uiState.selectedTab,
@@ -55,7 +56,8 @@ fun LazyListScope.feedSection(
         notes = uiState.currentTabState.notes,
         onNoteClick = onNoteClick,
         onNoteLikeClick = onNoteLikeClick,
-        onNoteBookmarkClick = onNoteBookmarkClick
+        onNoteBookmarkClick = onNoteBookmarkClick,
+        onNoteMenuClick = onNoteMenuClick,
     )
 }
 
@@ -138,6 +140,7 @@ private fun LazyListScope.feedSectionNotes(
     onNoteClick: (Long) -> Unit,
     onNoteLikeClick: (Long) -> Unit,
     onNoteBookmarkClick: (Long) -> Unit,
+    onNoteMenuClick: (NoteComponentData) -> Unit,
 ) {
     if (notes.isEmpty()) {
         item(key = "feedEmptyState") {
@@ -156,6 +159,7 @@ private fun LazyListScope.feedSectionNotes(
             onClick = { onNoteClick(note.id) },
             onLikeClick = { onNoteLikeClick(note.id) },
             onBookmarkClick = { onNoteBookmarkClick(note.id) },
+            onMenuClick = onNoteMenuClick,
             modifier = Modifier.fillMaxWidth()
         )
     }

--- a/app/src/main/java/com/lyrics/feelin/presentation/view/mypage/MyPageScreen.kt
+++ b/app/src/main/java/com/lyrics/feelin/presentation/view/mypage/MyPageScreen.kt
@@ -35,6 +35,8 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -60,6 +62,8 @@ import com.lyrics.feelin.presentation.designsystem.theme.FeelinTheme
 import com.lyrics.feelin.presentation.designsystem.theme.FeelinTypography
 import com.lyrics.feelin.presentation.designsystem.theme.LocalFeelinColors
 import com.lyrics.feelin.presentation.view.component.note.NoteComponent
+import com.lyrics.feelin.presentation.view.component.note.NoteComponentData
+import com.lyrics.feelin.presentation.view.component.note.NoteMenuBottomSheet
 import com.lyrics.feelin.presentation.view.component.profile.ProfileComponent
 
 private const val NICKNAME_CARET_ROTATION_DEGREES = 270f
@@ -70,9 +74,12 @@ fun MyPageScreen(
     onSettingClick: () -> Unit,
     modifier: Modifier = Modifier,
     onNoteClick: (Long) -> Unit = {},
+    onNoteReportClick: (Long) -> Unit = {},
+    currentUserId: Long? = null,
     viewModel: MyPageViewModel = hiltViewModel(),
 ) {
     val myPageState by viewModel.myPageScreenState.collectAsState()
+    var selectedNoteForMenu by remember { mutableStateOf<NoteComponentData?>(null) }
 
     val feelinColors = LocalFeelinColors.current
 
@@ -285,6 +292,7 @@ fun MyPageScreen(
                                         NoteComponent(
                                             noteData = it,
                                             onClick = { note -> onNoteClick(note.id) },
+                                            onMenuClick = { note -> selectedNoteForMenu = note },
                                         )
                                     }
                                 }
@@ -320,6 +328,18 @@ fun MyPageScreen(
                     )
                 }
             }
+        }
+
+        selectedNoteForMenu?.let { selectedNote ->
+            NoteMenuBottomSheet(
+                noteData = selectedNote,
+                currentUserId = currentUserId,
+                onReportClick = { noteId ->
+                    selectedNoteForMenu = null
+                    onNoteReportClick(noteId)
+                },
+                onDismissRequest = { selectedNoteForMenu = null },
+            )
         }
     }
 }

--- a/app/src/main/java/com/lyrics/feelin/presentation/view/mypage/MyPageScreen.kt
+++ b/app/src/main/java/com/lyrics/feelin/presentation/view/mypage/MyPageScreen.kt
@@ -75,10 +75,10 @@ fun MyPageScreen(
     modifier: Modifier = Modifier,
     onNoteClick: (Long) -> Unit = {},
     onNoteReportClick: (Long) -> Unit = {},
-    currentUserId: Long? = null,
     viewModel: MyPageViewModel = hiltViewModel(),
 ) {
     val myPageState by viewModel.myPageScreenState.collectAsState()
+    val currentUserId by viewModel.currentUserId.collectAsState()
     var selectedNoteForMenu by remember { mutableStateOf<NoteComponentData?>(null) }
 
     val feelinColors = LocalFeelinColors.current

--- a/app/src/main/java/com/lyrics/feelin/presentation/view/mypage/MyPageViewModel.kt
+++ b/app/src/main/java/com/lyrics/feelin/presentation/view/mypage/MyPageViewModel.kt
@@ -20,6 +20,7 @@ class MyPageViewModel @Inject constructor(
 ) : ViewModel() {
     private val _myPageScreenStatus: MutableStateFlow<MyPageScreenState> = MutableStateFlow(MyPageScreenState.initial())
     val myPageScreenState: StateFlow<MyPageScreenState> = _myPageScreenStatus.asStateFlow()
+    val currentUserId: StateFlow<Long?> = authRepository.userId
 
     private val _logoutStatus: MutableStateFlow<MyPageLogoutStatus> = MutableStateFlow(MyPageLogoutStatus.IDLE)
     val logoutStatus: StateFlow<MyPageLogoutStatus> = _logoutStatus.asStateFlow()

--- a/app/src/main/java/com/lyrics/feelin/presentation/view/note/detail/NoteDetailScreen.kt
+++ b/app/src/main/java/com/lyrics/feelin/presentation/view/note/detail/NoteDetailScreen.kt
@@ -29,7 +29,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.buildAnnotatedString
@@ -46,12 +48,15 @@ import com.lyrics.feelin.presentation.view.component.comment.CommentComponentDat
 import com.lyrics.feelin.presentation.view.component.comment.CommentInputField
 import com.lyrics.feelin.presentation.view.component.note.NoteComponent
 import com.lyrics.feelin.presentation.view.component.note.NoteComponentData
+import com.lyrics.feelin.presentation.view.component.note.NoteMenuBottomSheet
 
 @Composable
 fun NoteDetailScreen(
     noteId: Long,
     onBackClick: () -> Unit,
     modifier: Modifier = Modifier,
+    onNoteReportClick: (Long) -> Unit = {},
+    currentUserId: Long? = null,
     viewModel: NoteDetailViewModel = hiltViewModel(),
 ) {
     val viewState by viewModel.viewState.collectAsState()
@@ -65,6 +70,8 @@ fun NoteDetailScreen(
         viewState = viewState,
         commentInputState = commentInputState,
         onBackClick = onBackClick,
+        onNoteReportClick = onNoteReportClick,
+        currentUserId = currentUserId,
         onCommentMoreClick = viewModel::selectComment,
         onSendComment = viewModel::writeComment,
         modifier = modifier,
@@ -76,11 +83,14 @@ private fun NoteDetailContent(
     viewState: NoteDetailViewState,
     commentInputState: TextFieldState,
     onBackClick: () -> Unit,
+    onNoteReportClick: (Long) -> Unit,
+    currentUserId: Long?,
     onCommentMoreClick: (CommentComponentData) -> Unit,
     onSendComment: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val feelinColors = LocalFeelinColors.current
+    var selectedNoteForMenu by remember { mutableStateOf<NoteComponentData?>(null) }
 
     Scaffold(
         modifier = modifier
@@ -113,6 +123,7 @@ private fun NoteDetailContent(
             NoteDetailStatus.LOADING -> NoteDetailLoadingContent(innerPadding = innerPadding)
             NoteDetailStatus.SUCCESS -> NoteDetailSuccessContent(
                 viewState = viewState,
+                onNoteMenuClick = { selectedNoteForMenu = it },
                 onCommentMoreClick = onCommentMoreClick,
                 innerPadding = innerPadding,
             )
@@ -121,6 +132,18 @@ private fun NoteDetailContent(
                 innerPadding = innerPadding,
             )
         }
+    }
+
+    selectedNoteForMenu?.let { selectedNote ->
+        NoteMenuBottomSheet(
+            noteData = selectedNote,
+            currentUserId = currentUserId,
+            onReportClick = { selectedNoteId ->
+                selectedNoteForMenu = null
+                onNoteReportClick(selectedNoteId)
+            },
+            onDismissRequest = { selectedNoteForMenu = null },
+        )
     }
 }
 
@@ -139,6 +162,7 @@ private fun NoteDetailLoadingContent(innerPadding: PaddingValues, modifier: Modi
 @Composable
 private fun NoteDetailSuccessContent(
     viewState: NoteDetailViewState,
+    onNoteMenuClick: (NoteComponentData) -> Unit,
     onCommentMoreClick: (CommentComponentData) -> Unit,
     innerPadding: PaddingValues,
     modifier: Modifier = Modifier,
@@ -153,7 +177,10 @@ private fun NoteDetailSuccessContent(
             .fillMaxSize(),
     ) {
         item {
-            NoteComponent(noteData = viewState.note)
+            NoteComponent(
+                noteData = viewState.note,
+                onMenuClick = onNoteMenuClick,
+            )
             if (hasComments) {
                 HorizontalDivider(color = feelinColors.backgroundTertiary, thickness = 8.dp)
             }
@@ -248,6 +275,8 @@ private fun NoteDetailScreenPreview() {
             ),
             commentInputState = remember { TextFieldState() },
             onBackClick = {},
+            onNoteReportClick = {},
+            currentUserId = null,
             onCommentMoreClick = {},
             onSendComment = {},
         )
@@ -271,6 +300,8 @@ private fun NoteDetailNoCommentScreenPreview() {
             ),
             commentInputState = remember { TextFieldState() },
             onBackClick = {},
+            onNoteReportClick = {},
+            currentUserId = null,
             onCommentMoreClick = {},
             onSendComment = {},
         )

--- a/app/src/main/java/com/lyrics/feelin/presentation/view/note/report/NoteReportScreen.kt
+++ b/app/src/main/java/com/lyrics/feelin/presentation/view/note/report/NoteReportScreen.kt
@@ -1,0 +1,231 @@
+package com.lyrics.feelin.presentation.view.note.report
+
+import android.content.res.Configuration
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.lyrics.feelin.core.designsystem.component.FeelinCheckboxItem
+import com.lyrics.feelin.core.designsystem.component.FeelinModalDialog
+import com.lyrics.feelin.core.designsystem.component.FeelinNormalButton
+import com.lyrics.feelin.core.designsystem.component.FeelinTopAppBarWithBack
+import com.lyrics.feelin.presentation.designsystem.theme.FeelinTheme
+import com.lyrics.feelin.presentation.designsystem.theme.FeelinTypography
+import com.lyrics.feelin.presentation.designsystem.theme.LocalFeelinColors
+
+private val reportReasons = listOf(
+    "커뮤니티 성격에 맞지 않음",
+    "타 유저 혹은 아티스트 비방",
+    "불쾌감을 조성하는 음란성 / 선정적인 내용",
+    "상업적 광고",
+    "부적절한 정보 유출",
+    "정치적인 내용 / 종교 포교 시도",
+    "기타"
+)
+
+enum class NoteReportDialogType {
+    Success,
+    Duplicate,
+}
+
+@Suppress("UnusedParameter")
+@Composable
+fun NoteReportScreen(
+    noteId: Long,
+    onBackClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    initialDialogType: NoteReportDialogType? = null,
+) {
+    var selectedReason by remember { mutableStateOf<String?>(null) }
+    var otherReasonText by remember { mutableStateOf("") }
+    var isAgreed by remember { mutableStateOf(false) }
+
+    var visibleDialogType by remember { mutableStateOf(initialDialogType) }
+
+    val isSubmitEnabled = selectedReason != null && isAgreed &&
+        (selectedReason != "기타" || otherReasonText.isNotBlank())
+
+    val feelinColors = LocalFeelinColors.current
+
+    Scaffold(
+        modifier = modifier.fillMaxSize(),
+        topBar = {
+            FeelinTopAppBarWithBack(
+                title = "신고하기",
+                onBackClick = onBackClick
+            )
+        },
+        bottomBar = {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(feelinColors.backgroundPrimary)
+                    .padding(vertical = 12.dp)
+            ) {
+                FeelinCheckboxItem(
+                    checked = isAgreed,
+                    onCheckedChange = { isAgreed = it },
+                    text = "개인정보 수집에 동의합니다.",
+                    required = true
+                )
+                Spacer(modifier = Modifier.height(16.dp))
+                FeelinNormalButton(
+                    text = "신고하기",
+                    enabled = isSubmitEnabled,
+                    onClick = { visibleDialogType = NoteReportDialogType.Success },
+                    modifier = Modifier.padding(horizontal = 20.dp)
+                )
+            }
+        },
+        containerColor = feelinColors.backgroundPrimary,
+        contentWindowInsets = WindowInsets(0)
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .padding(innerPadding)
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+        ) {
+            Spacer(modifier = Modifier.height(12.dp))
+
+            reportReasons.forEach { reason ->
+                FeelinRadioButtonItem(
+                    selected = selectedReason == reason,
+                    text = reason,
+                    onClick = {
+                        selectedReason = reason
+                        if (reason != "기타") {
+                            otherReasonText = ""
+                        }
+                    }
+                )
+            }
+
+            if (selectedReason == "기타") {
+                BasicTextField(
+                    value = otherReasonText,
+                    onValueChange = { otherReasonText = it },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 20.dp, vertical = 8.dp)
+                        .heightIn(min = 64.dp, max = 144.dp)
+                        .background(color = feelinColors.inputField, shape = RoundedCornerShape(8.dp))
+                        .padding(16.dp),
+                    textStyle = FeelinTypography.body1.copy(color = feelinColors.gray09),
+                    cursorBrush = SolidColor(feelinColors.brandPrimary),
+                    decorationBox = { innerTextField ->
+                        Box {
+                            if (otherReasonText.isEmpty()) {
+                                Text(
+                                    text = "신고사유를 작성해주세요.",
+                                    style = FeelinTypography.body1,
+                                    color = feelinColors.gray04
+                                )
+                            }
+                            innerTextField()
+                        }
+                    }
+                )
+            }
+
+            Text(
+                text = "*관리자 검토 진행 후 신고가 반려될 수 있으며, 고의적인 허위신고가 반복될 경우 서비스 이용이 제한될 수 있습니다.",
+                style = FeelinTypography.caption1,
+                color = feelinColors.gray05,
+                modifier = Modifier.padding(horizontal = 20.dp, vertical = 16.dp)
+            )
+
+            Spacer(modifier = Modifier.height(24.dp))
+        }
+    }
+
+    visibleDialogType?.let { dialogType ->
+        FeelinModalDialog(
+            title = when (dialogType) {
+                NoteReportDialogType.Success -> "신고가 접수되었어요."
+                NoteReportDialogType.Duplicate -> "이미 신고되었어요."
+            },
+            description = null,
+            confirmButtonText = "확인",
+            onConfirmButtonClick = {
+                visibleDialogType = null
+                if (dialogType == NoteReportDialogType.Success) {
+                    onBackClick()
+                }
+            },
+            isDismissButtonEnable = false
+        )
+    }
+}
+
+@Composable
+private fun FeelinRadioButtonItem(
+    selected: Boolean,
+    text: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val feelinColors = LocalFeelinColors.current
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(horizontal = 20.dp, vertical = 14.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Box(
+            modifier = Modifier
+                .size(24.dp)
+                .border(
+                    width = if (selected) 6.dp else 1.5.dp,
+                    color = if (selected) feelinColors.brandPrimary else feelinColors.gray02,
+                    shape = CircleShape
+                )
+        )
+        Spacer(modifier = Modifier.size(12.dp))
+        Text(
+            text = text,
+            style = FeelinTypography.title2,
+            color = feelinColors.gray09
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Preview(showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+private fun NoteReportScreenPreview() {
+    FeelinTheme {
+        NoteReportScreen(
+            noteId = 1L,
+            onBackClick = {}
+        )
+    }
+}

--- a/app/src/main/java/com/lyrics/feelin/presentation/view/note/report/NoteReportScreen.kt
+++ b/app/src/main/java/com/lyrics/feelin/presentation/view/note/report/NoteReportScreen.kt
@@ -3,9 +3,10 @@ package com.lyrics.feelin.presentation.view.note.report
 import android.content.res.Configuration
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
@@ -13,13 +14,17 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -29,13 +34,17 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.lyrics.feelin.core.designsystem.component.FeelinCheckboxItem
 import com.lyrics.feelin.core.designsystem.component.FeelinModalDialog
 import com.lyrics.feelin.core.designsystem.component.FeelinNormalButton
+import com.lyrics.feelin.core.designsystem.component.FeelinTopAppBarDefaults
 import com.lyrics.feelin.core.designsystem.component.FeelinTopAppBarWithBack
+import com.lyrics.feelin.core.designsystem.icon.CheckBoxIconEnabled
 import com.lyrics.feelin.presentation.designsystem.theme.FeelinTheme
 import com.lyrics.feelin.presentation.designsystem.theme.FeelinTypography
 import com.lyrics.feelin.presentation.designsystem.theme.LocalFeelinColors
@@ -75,11 +84,18 @@ fun NoteReportScreen(
     val feelinColors = LocalFeelinColors.current
 
     Scaffold(
-        modifier = modifier.fillMaxSize(),
+        modifier = modifier
+            .fillMaxSize()
+            .statusBarsPadding(),
         topBar = {
             FeelinTopAppBarWithBack(
                 title = "신고하기",
-                onBackClick = onBackClick
+                onBackClick = onBackClick,
+                paddingValues = PaddingValues(
+                    horizontal = FeelinTopAppBarDefaults.HorizontalPadding,
+                    vertical = 10.dp,
+                ),
+                showDivider = false,
             )
         },
         bottomBar = {
@@ -87,6 +103,7 @@ fun NoteReportScreen(
                 modifier = Modifier
                     .fillMaxWidth()
                     .background(feelinColors.backgroundPrimary)
+                    .navigationBarsPadding()
                     .padding(vertical = 12.dp)
             ) {
                 FeelinCheckboxItem(
@@ -95,7 +112,7 @@ fun NoteReportScreen(
                     text = "개인정보 수집에 동의합니다.",
                     required = true
                 )
-                Spacer(modifier = Modifier.height(16.dp))
+                Spacer(modifier = Modifier.height(32.dp))
                 FeelinNormalButton(
                     text = "신고하기",
                     enabled = isSubmitEnabled,
@@ -113,19 +130,33 @@ fun NoteReportScreen(
                 .fillMaxSize()
                 .verticalScroll(rememberScrollState())
         ) {
-            Spacer(modifier = Modifier.height(12.dp))
+            Spacer(modifier = Modifier.height(24.dp))
 
-            reportReasons.forEach { reason ->
-                FeelinRadioButtonItem(
-                    selected = selectedReason == reason,
-                    text = reason,
-                    onClick = {
-                        selectedReason = reason
-                        if (reason != "기타") {
-                            otherReasonText = ""
+            Text(
+                text = "신고사유",
+                style = FeelinTypography.heading3,
+                color = feelinColors.gray09,
+                modifier = Modifier.padding(horizontal = 20.dp),
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            Column(
+                modifier = Modifier.padding(horizontal = 20.dp),
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+            ) {
+                reportReasons.forEach { reason ->
+                    ReportReasonItem(
+                        selected = selectedReason == reason,
+                        text = reason,
+                        onClick = {
+                            selectedReason = reason
+                            if (reason != "기타") {
+                                otherReasonText = ""
+                            }
                         }
-                    }
-                )
+                    )
+                }
             }
 
             if (selectedReason == "기타") {
@@ -159,7 +190,11 @@ fun NoteReportScreen(
                 text = "*관리자 검토 진행 후 신고가 반려될 수 있으며, 고의적인 허위신고가 반복될 경우 서비스 이용이 제한될 수 있습니다.",
                 style = FeelinTypography.caption1,
                 color = feelinColors.gray05,
-                modifier = Modifier.padding(horizontal = 20.dp, vertical = 16.dp)
+                modifier = Modifier.padding(
+                    start = 20.dp,
+                    top = 24.dp,
+                    end = 20.dp,
+                ),
             )
 
             Spacer(modifier = Modifier.height(24.dp))
@@ -186,7 +221,7 @@ fun NoteReportScreen(
 }
 
 @Composable
-private fun FeelinRadioButtonItem(
+private fun ReportReasonItem(
     selected: Boolean,
     text: String,
     onClick: () -> Unit,
@@ -196,23 +231,35 @@ private fun FeelinRadioButtonItem(
     Row(
         modifier = modifier
             .fillMaxWidth()
-            .clickable(onClick = onClick)
-            .padding(horizontal = 20.dp, vertical = 14.dp),
+            .selectable(
+                selected = selected,
+                onClick = onClick,
+                role = Role.RadioButton,
+            ),
         verticalAlignment = Alignment.CenterVertically
     ) {
-        Box(
-            modifier = Modifier
-                .size(24.dp)
-                .border(
-                    width = if (selected) 6.dp else 1.5.dp,
-                    color = if (selected) feelinColors.brandPrimary else feelinColors.gray02,
-                    shape = CircleShape
-                )
-        )
-        Spacer(modifier = Modifier.size(12.dp))
+        if (selected) {
+            Icon(
+                imageVector = CheckBoxIconEnabled,
+                contentDescription = "선택됨",
+                tint = Color.Unspecified,
+                modifier = Modifier.size(24.dp),
+            )
+        } else {
+            Box(
+                modifier = Modifier
+                    .size(24.dp)
+                    .border(
+                        width = 1.dp,
+                        color = feelinColors.gray02,
+                        shape = CircleShape,
+                    ),
+            )
+        }
+        Spacer(modifier = Modifier.size(8.dp))
         Text(
             text = text,
-            style = FeelinTypography.title2,
+            style = FeelinTypography.body1,
             color = feelinColors.gray09
         )
     }

--- a/app/src/main/java/com/lyrics/feelin/presentation/view/note/search/result/NoteSearchResultScreen.kt
+++ b/app/src/main/java/com/lyrics/feelin/presentation/view/note/search/result/NoteSearchResultScreen.kt
@@ -67,6 +67,8 @@ import com.lyrics.feelin.presentation.designsystem.theme.FeelinTypography
 import com.lyrics.feelin.presentation.designsystem.theme.LocalFeelinColors
 import com.lyrics.feelin.presentation.util.label
 import com.lyrics.feelin.presentation.view.component.note.NoteComponent
+import com.lyrics.feelin.presentation.view.component.note.NoteComponentData
+import com.lyrics.feelin.presentation.view.component.note.NoteMenuBottomSheet
 import kotlinx.coroutines.flow.collectLatest
 
 private enum class HeaderState {
@@ -135,6 +137,8 @@ fun NoteSearchResultScreen(
     onBackClick: () -> Unit,
     modifier: Modifier = Modifier,
     onNoteClick: (Long) -> Unit = {},
+    onNoteReportClick: (Long) -> Unit = {},
+    currentUserId: Long? = null,
     viewModel: NoteSearchResultViewModel = viewModel(),
 ) {
     val viewState by viewModel.viewState.collectAsState()
@@ -142,6 +146,7 @@ fun NoteSearchResultScreen(
     val density = LocalDensity.current
     val listState = rememberLazyListState()
     val headerState = rememberHeaderState(listState)
+    var selectedNoteForMenu by remember { mutableStateOf<NoteComponentData?>(null) }
     val pinnedFilterTopPadding = if (headerState == HeaderState.CollapsedBarOnly) {
         COLLAPSED_TOP_BAR_HEIGHT.dp
     } else {
@@ -254,6 +259,7 @@ fun NoteSearchResultScreen(
                         NoteComponent(
                             noteData = note,
                             onClick = { onNoteClick(it.id) },
+                            onMenuClick = { selectedNoteForMenu = it },
                         )
                     }
 
@@ -296,6 +302,18 @@ fun NoteSearchResultScreen(
                 TopicFilterRow(
                     selectedNoteTopic = viewState.selectedNoteTopic,
                     onTopicSelect = viewModel::selectTopic,
+                )
+            }
+
+            selectedNoteForMenu?.let { selectedNote ->
+                NoteMenuBottomSheet(
+                    noteData = selectedNote,
+                    currentUserId = currentUserId,
+                    onReportClick = { noteId ->
+                        selectedNoteForMenu = null
+                        onNoteReportClick(noteId)
+                    },
+                    onDismissRequest = { selectedNoteForMenu = null },
                 )
             }
         }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] The commit message follows our guidelines

## What kind of change does this PR introduce?
- Add feature
- Implement design

# What is the current behavior?
노트 메뉴에서 신고 화면으로 진입할 수 없으며, 신고 사유를 선택하고 제출하는 화면이 구현되어 있지 않았습니다.

# What is the new behavior (if this is a feature change)?
노트 메뉴 바텀시트와 신고 화면을 추가하고 주요 노트 화면에 연결했습니다.

- 신고 사유 선택, 기타 사유 입력, 개인정보 수집 동의를 지원하는 `NoteReportScreen`을 구현했습니다.
  - 이 화면의 내부 컴포넌트로 라디오버튼 기능을 수행하는 체크박스 컴포넌트를 추가했습니다. (User) 
- 필수 항목을 입력하면 신고 버튼이 활성화되고 접수 결과 다이얼로그가 표시됩니다.
- 작성자 여부에 따라 수정·삭제 또는 신고·차단 메뉴를 보여주는 `NoteMenuBottomSheet`를 추가했습니다.
- 홈, 커뮤니티, 마이페이지, 검색 결과, 노트 상세 화면에서 신고 화면으로 이동하도록 내비게이션을 연결했습니다.
- 기본 화면, 기타 사유 선택, 신고 제출 흐름을 검증하는 Compose UI 테스트를 추가했습니다.

## Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No breaking changes.

## ScreenShots (If needed)

### Light mode

<p>
  <img width="200" alt="Screenshot_20260711_230555_ DEV  Feelin" src="https://github.com/user-attachments/assets/b9b4d89e-2d78-4b03-a2e0-ae70b3fbafc0" />
  <img width="200" alt="Screenshot_20260712_233749_ DEV  Feelin" src="https://github.com/user-attachments/assets/061b4256-cb47-4426-b9ef-1c42d92de216" />
  <img width="200" alt="Screenshot_20260712_233757_ DEV  Feelin" src="https://github.com/user-attachments/assets/57dbab39-77a8-417e-8c0b-7334f11b3dcf" />
</p>

### Dark mode

<p>
  <img width="200" alt="Screenshot_20260711_230603_ DEV  Feelin" src="https://github.com/user-attachments/assets/ad036d32-d217-473f-a828-29a0178d1c8e" />
  <img width="200" alt="Screenshot_20260712_231016_ DEV  Feelin" src="https://github.com/user-attachments/assets/15c962b7-b4b9-46fd-af9f-ab60f13e11b7" />
  <img width="200" alt="Screenshot_20260712_231024_ DEV  Feelin" src="https://github.com/user-attachments/assets/0aac981e-1706-4f9c-85b8-70d7ef1617f4" />
  <img width="200" alt="Screenshot_20260712_231026_ DEV  Feelin" src="https://github.com/user-attachments/assets/8f590e57-8072-448b-a0e1-b2302f1e8e45" />
  <img width="200" alt="Screenshot_20260712_233826_ DEV  Feelin" src="https://github.com/user-attachments/assets/4d0cc364-0eae-469d-b8ac-ed1fcb00b203" />
</p>


## Other information:
### AI Agent
- 변경 파일: 15개
- 추가: 619줄
- 삭제: 5줄

### User
이번 화면 레이아웃 구현중 확인한 부분인데, FeelinCheckbox의 disabled icon이 다크모드에 대응하지 않는 것을 확인했습니다. 이를 별도의 이슈로 등록한 후 추후 수정하겠습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Introduced a dedicated note reporting screen with selectable reasons, optional “기타” details, required consent, and submission success/duplicate feedback.
  - Added note action menus throughout the app (feed, search results, note details, community, and My Page), showing edit/delete for your notes and report/block for others.
  - Wired navigation so menu “report” actions open the reporting flow for the selected note.

- **Style**
  - Refined bottom-sheet appearance (rounded corners) and improved action-row icon sizing/spacing.

- **Tests**
  - Added UI test coverage for report selection, validation, submission, and confirmation states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->