### PR TITLE
SCRUM-283 design: Add notification screen

### DIFF
--- a/app/src/androidTest/java/com/lyrics/feelin/presentation/view/notification/NotificationScreenTest.kt
+++ b/app/src/androidTest/java/com/lyrics/feelin/presentation/view/notification/NotificationScreenTest.kt
@@ -1,0 +1,56 @@
+package com.lyrics.feelin.presentation.view.notification
+
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import com.lyrics.feelin.presentation.designsystem.theme.FeelinTheme
+import org.junit.Rule
+import org.junit.Test
+
+class NotificationScreenTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun topBarShowsBackWithoutEdit() {
+        setContent(NotificationUiState.populatedSample())
+
+        composeTestRule.onNodeWithContentDescription("Back").assertIsDisplayed()
+        composeTestRule.onNodeWithText("편집").assertDoesNotExist()
+    }
+
+    @Test
+    fun emptyStateShowsText() {
+        setContent(NotificationUiState.emptySample())
+
+        composeTestRule.onNodeWithText("새로운 알림이 없어요").assertIsDisplayed()
+    }
+
+    @Test
+    fun populatedStateShowsDividersExceptAfterLastItem() {
+        val uiState = NotificationUiState.populatedSample()
+
+        setContent(uiState)
+
+        composeTestRule.onAllNodesWithTag("notificationDivider")
+            .assertCountEquals(uiState.items.lastIndex)
+    }
+
+    private fun setContent(uiState: NotificationUiState) {
+        composeTestRule.setContent {
+            FeelinTheme {
+                NotificationScreen(
+                    uiState = uiState,
+                    onBackClick = {},
+                    onTabClick = {},
+                    onNotificationClick = {},
+                    onDialogConfirmClick = {},
+                )
+            }
+        }
+    }
+}

--- a/app/src/androidTest/java/com/lyrics/feelin/presentation/view/notification/component/NotificationListItemTest.kt
+++ b/app/src/androidTest/java/com/lyrics/feelin/presentation/view/notification/component/NotificationListItemTest.kt
@@ -1,0 +1,52 @@
+package com.lyrics.feelin.presentation.view.notification.component
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import com.lyrics.feelin.presentation.designsystem.theme.FeelinTheme
+import com.lyrics.feelin.presentation.view.notification.NotificationItemUiModel
+import org.junit.Rule
+import org.junit.Test
+
+class NotificationListItemTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun unreadItemShowsUnreadIndicator() {
+        setContent(isRead = false)
+
+        composeTestRule.onNodeWithTag(
+            testTag = "notificationUnreadIndicator",
+            useUnmergedTree = true,
+        ).assertIsDisplayed()
+    }
+
+    @Test
+    fun readItemHidesUnreadIndicator() {
+        setContent(isRead = true)
+
+        composeTestRule.onNodeWithTag(
+            testTag = "notificationUnreadIndicator",
+            useUnmergedTree = true,
+        ).assertDoesNotExist()
+    }
+
+    private fun setContent(isRead: Boolean) {
+        composeTestRule.setContent {
+            FeelinTheme {
+                NotificationListItem(
+                    item = NotificationItemUiModel(
+                        id = 1L,
+                        message = "알림 메시지",
+                        timeLabel = "방금 전",
+                        imageUrl = null,
+                        isRead = isRead,
+                    ),
+                    onClick = {},
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/lyrics/feelin/navigation/FeelinDestination.kt
+++ b/app/src/main/java/com/lyrics/feelin/navigation/FeelinDestination.kt
@@ -38,6 +38,7 @@ sealed class FeelinDestination(
 
     // Main Flow (with Bottom Navigation)
     object Home : FeelinDestination(route = "home")
+    object Notification : FeelinDestination(route = "notification")
     object ArtistRecord : FeelinDestination(route = "artist_record/{$ARTIST_ID_ARGUMENT}") {
         const val ArtistIdArgument = ARTIST_ID_ARGUMENT
 

--- a/app/src/main/java/com/lyrics/feelin/navigation/FeelinNavHost.kt
+++ b/app/src/main/java/com/lyrics/feelin/navigation/FeelinNavHost.kt
@@ -63,7 +63,7 @@ import com.lyrics.feelin.presentation.view.note.report.NoteReportScreen
 import com.lyrics.feelin.presentation.view.note.search.NoteSearchScreen
 import com.lyrics.feelin.presentation.view.note.search.result.NoteSearchResultScreen
 import com.lyrics.feelin.presentation.view.notification.NotificationScreen
-import com.lyrics.feelin.presentation.view.notification.NotificationUiState
+import com.lyrics.feelin.presentation.view.notification.NotificationViewModel
 import com.lyrics.feelin.presentation.view.onboarding.OnboardingUiState
 import com.lyrics.feelin.presentation.view.onboarding.OnboardingViewModel
 import com.lyrics.feelin.presentation.view.onboarding.genderage.OnboardingGenderAgeScreen
@@ -308,10 +308,13 @@ private fun NavGraphBuilder.mainNavGraph(navController: NavHostController) {
         }
 
         composable(FeelinDestination.Notification.route) {
+            val viewModel: NotificationViewModel = hiltViewModel()
+            val uiState by viewModel.uiState.collectAsState()
+
             NotificationScreen(
-                uiState = NotificationUiState.populatedSample(),
-                onEditClick = {},
-                onTabClick = {},
+                uiState = uiState,
+                onBackClick = { navController.popBackStack() },
+                onTabClick = viewModel::selectTab,
                 onNotificationClick = {},
                 onDialogConfirmClick = {},
             )

--- a/app/src/main/java/com/lyrics/feelin/navigation/FeelinNavHost.kt
+++ b/app/src/main/java/com/lyrics/feelin/navigation/FeelinNavHost.kt
@@ -62,6 +62,8 @@ import com.lyrics.feelin.presentation.view.note.detail.NoteDetailScreen
 import com.lyrics.feelin.presentation.view.note.report.NoteReportScreen
 import com.lyrics.feelin.presentation.view.note.search.NoteSearchScreen
 import com.lyrics.feelin.presentation.view.note.search.result.NoteSearchResultScreen
+import com.lyrics.feelin.presentation.view.notification.NotificationScreen
+import com.lyrics.feelin.presentation.view.notification.NotificationUiState
 import com.lyrics.feelin.presentation.view.onboarding.OnboardingUiState
 import com.lyrics.feelin.presentation.view.onboarding.OnboardingViewModel
 import com.lyrics.feelin.presentation.view.onboarding.genderage.OnboardingGenderAgeScreen
@@ -303,6 +305,16 @@ private fun NavGraphBuilder.mainNavGraph(navController: NavHostController) {
                     )
                 }
             }
+        }
+
+        composable(FeelinDestination.Notification.route) {
+            NotificationScreen(
+                uiState = NotificationUiState.populatedSample(),
+                onEditClick = {},
+                onTabClick = {},
+                onNotificationClick = {},
+                onDialogConfirmClick = {},
+            )
         }
 
         navigation(

--- a/app/src/main/java/com/lyrics/feelin/navigation/HomeNavigation.kt
+++ b/app/src/main/java/com/lyrics/feelin/navigation/HomeNavigation.kt
@@ -1,6 +1,5 @@
 package com.lyrics.feelin.navigation
 
-import android.util.Log
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavController
@@ -27,8 +26,7 @@ fun HomeRoute(
             navController.navigate(FeelinDestination.NoteReport.createRoute(noteId))
         },
         onNotificationClick = {
-            // TODO(@이대근): 추후 알림 화면 라우트 연결 2026.06.17.
-            Log.d("HomeRoute", "Notification clicked")
+            navController.navigate(FeelinDestination.Notification.route)
         }
     )
 }

--- a/app/src/main/java/com/lyrics/feelin/presentation/view/notification/NotificationScreen.kt
+++ b/app/src/main/java/com/lyrics/feelin/presentation/view/notification/NotificationScreen.kt
@@ -1,0 +1,196 @@
+package com.lyrics.feelin.presentation.view.notification
+
+import android.content.res.Configuration
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import com.lyrics.feelin.core.designsystem.component.FeelinModalDialog
+import com.lyrics.feelin.core.designsystem.component.FeelinTab
+import com.lyrics.feelin.core.designsystem.component.FeelinTabRow
+import com.lyrics.feelin.core.designsystem.component.FeelinTopAppBarNoBack
+import com.lyrics.feelin.presentation.designsystem.theme.FeelinTheme
+import com.lyrics.feelin.presentation.designsystem.theme.FeelinTypography
+import com.lyrics.feelin.presentation.designsystem.theme.LocalFeelinColors
+import com.lyrics.feelin.presentation.view.notification.component.NotificationEmptyState
+import com.lyrics.feelin.presentation.view.notification.component.NotificationListItem
+
+@Composable
+fun NotificationScreen(
+    uiState: NotificationUiState,
+    onEditClick: () -> Unit,
+    onTabClick: (NotificationTab) -> Unit,
+    onNotificationClick: (Long) -> Unit,
+    onDialogConfirmClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val feelinColors = LocalFeelinColors.current
+
+    Scaffold(
+        modifier = modifier
+            .background(color = feelinColors.backgroundPrimary)
+            .windowInsetsPadding(WindowInsets.systemBars.only(WindowInsetsSides.Top + WindowInsetsSides.Bottom)),
+        topBar = {
+            FeelinTopAppBarNoBack(
+                title = "알림",
+                centeredTitle = true,
+                actions = {
+                    if (uiState.items.isNotEmpty()) {
+                        Text(
+                            text = "편집",
+                            style = FeelinTypography.body1,
+                            color = feelinColors.gray09,
+                            modifier = Modifier.clickable(onClick = onEditClick)
+                        )
+                    }
+                }
+            )
+        }
+    ) { contentPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(feelinColors.backgroundPrimary)
+                .padding(contentPadding)
+        ) {
+            FeelinTabRow(
+                selectedTabIndex = uiState.selectedTab.ordinal
+            ) {
+                NotificationTab.values().forEach { tab ->
+                    FeelinTab(
+                        selected = uiState.selectedTab == tab,
+                        onClick = { onTabClick(tab) },
+                        text = { Text(text = tab.label) }
+                    )
+                }
+            }
+
+            if (uiState.items.isEmpty()) {
+                NotificationEmptyState(modifier = Modifier.weight(1f))
+            } else {
+                LazyColumn(modifier = Modifier.weight(1f)) {
+                    items(
+                        items = uiState.items,
+                        key = { it.id }
+                    ) { item ->
+                        NotificationListItem(
+                            item = item,
+                            onClick = onNotificationClick
+                        )
+                    }
+                }
+            }
+        }
+
+        if (uiState.isDeletedNoteDialogVisible) {
+            FeelinModalDialog(
+                title = "이미 삭제된 노트예요.",
+                description = null,
+                confirmButtonText = "확인",
+                onConfirmButtonClick = onDialogConfirmClick,
+                isDismissButtonEnable = false
+            )
+        }
+    }
+}
+
+@Preview(
+    name = "Notification Screen - Populated - Light",
+    showBackground = true
+)
+@Preview(
+    name = "Notification Screen - Populated - Dark",
+    showBackground = true,
+    uiMode = Configuration.UI_MODE_NIGHT_YES
+)
+@Composable
+private fun NotificationScreenPopulatedPreview() {
+    FeelinTheme {
+        NotificationScreen(
+            uiState = NotificationUiState.populatedSample(),
+            onEditClick = {},
+            onTabClick = {},
+            onNotificationClick = {},
+            onDialogConfirmClick = {}
+        )
+    }
+}
+
+@Preview(
+    name = "Notification Screen - Empty - Light",
+    showBackground = true
+)
+@Preview(
+    name = "Notification Screen - Empty - Dark",
+    showBackground = true,
+    uiMode = Configuration.UI_MODE_NIGHT_YES
+)
+@Composable
+private fun NotificationScreenEmptyPreview() {
+    FeelinTheme {
+        NotificationScreen(
+            uiState = NotificationUiState.emptySample(),
+            onEditClick = {},
+            onTabClick = {},
+            onNotificationClick = {},
+            onDialogConfirmClick = {}
+        )
+    }
+}
+
+@Preview(
+    name = "Notification Screen - Report - Light",
+    showBackground = true
+)
+@Preview(
+    name = "Notification Screen - Report - Dark",
+    showBackground = true,
+    uiMode = Configuration.UI_MODE_NIGHT_YES
+)
+@Composable
+private fun NotificationScreenReportPreview() {
+    FeelinTheme {
+        NotificationScreen(
+            uiState = NotificationUiState.reportSample(),
+            onEditClick = {},
+            onTabClick = {},
+            onNotificationClick = {},
+            onDialogConfirmClick = {}
+        )
+    }
+}
+
+@Preview(
+    name = "Notification Screen - Deleted Note Dialog - Light",
+    showBackground = true
+)
+@Preview(
+    name = "Notification Screen - Deleted Note Dialog - Dark",
+    showBackground = true,
+    uiMode = Configuration.UI_MODE_NIGHT_YES
+)
+@Composable
+private fun NotificationScreenDeletedNoteDialogPreview() {
+    FeelinTheme {
+        NotificationScreen(
+            uiState = NotificationUiState.deletedNoteDialogSample(),
+            onEditClick = {},
+            onTabClick = {},
+            onNotificationClick = {},
+            onDialogConfirmClick = {}
+        )
+    }
+}

--- a/app/src/main/java/com/lyrics/feelin/presentation/view/notification/NotificationScreen.kt
+++ b/app/src/main/java/com/lyrics/feelin/presentation/view/notification/NotificationScreen.kt
@@ -2,7 +2,6 @@ package com.lyrics.feelin.presentation.view.notification
 
 import android.content.res.Configuration
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
@@ -12,18 +11,20 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import com.lyrics.feelin.core.designsystem.component.FeelinModalDialog
 import com.lyrics.feelin.core.designsystem.component.FeelinTab
 import com.lyrics.feelin.core.designsystem.component.FeelinTabRow
-import com.lyrics.feelin.core.designsystem.component.FeelinTopAppBarNoBack
+import com.lyrics.feelin.core.designsystem.component.FeelinTopAppBarWithBack
 import com.lyrics.feelin.presentation.designsystem.theme.FeelinTheme
-import com.lyrics.feelin.presentation.designsystem.theme.FeelinTypography
 import com.lyrics.feelin.presentation.designsystem.theme.LocalFeelinColors
 import com.lyrics.feelin.presentation.view.notification.component.NotificationEmptyState
 import com.lyrics.feelin.presentation.view.notification.component.NotificationListItem
@@ -31,7 +32,7 @@ import com.lyrics.feelin.presentation.view.notification.component.NotificationLi
 @Composable
 fun NotificationScreen(
     uiState: NotificationUiState,
-    onEditClick: () -> Unit,
+    onBackClick: () -> Unit,
     onTabClick: (NotificationTab) -> Unit,
     onNotificationClick: (Long) -> Unit,
     onDialogConfirmClick: () -> Unit,
@@ -44,19 +45,11 @@ fun NotificationScreen(
             .background(color = feelinColors.backgroundPrimary)
             .windowInsetsPadding(WindowInsets.systemBars.only(WindowInsetsSides.Top + WindowInsetsSides.Bottom)),
         topBar = {
-            FeelinTopAppBarNoBack(
+            FeelinTopAppBarWithBack(
                 title = "알림",
+                onBackClick = onBackClick,
                 centeredTitle = true,
-                actions = {
-                    if (uiState.items.isNotEmpty()) {
-                        Text(
-                            text = "편집",
-                            style = FeelinTypography.body1,
-                            color = feelinColors.gray09,
-                            modifier = Modifier.clickable(onClick = onEditClick)
-                        )
-                    }
-                }
+                showDivider = false,
             )
         }
     ) { contentPadding ->
@@ -69,7 +62,7 @@ fun NotificationScreen(
             FeelinTabRow(
                 selectedTabIndex = uiState.selectedTab.ordinal
             ) {
-                NotificationTab.values().forEach { tab ->
+                NotificationTab.entries.forEach { tab ->
                     FeelinTab(
                         selected = uiState.selectedTab == tab,
                         onClick = { onTabClick(tab) },
@@ -82,14 +75,21 @@ fun NotificationScreen(
                 NotificationEmptyState(modifier = Modifier.weight(1f))
             } else {
                 LazyColumn(modifier = Modifier.weight(1f)) {
-                    items(
+                    itemsIndexed(
                         items = uiState.items,
-                        key = { it.id }
-                    ) { item ->
+                        key = { _, item -> item.id }
+                    ) { index, item ->
                         NotificationListItem(
                             item = item,
                             onClick = onNotificationClick
                         )
+                        if (index != uiState.items.lastIndex) {
+                            HorizontalDivider(
+                                modifier = Modifier.testTag("notificationDivider"),
+                                thickness = 1.dp,
+                                color = feelinColors.gray01
+                            )
+                        }
                     }
                 }
             }
@@ -121,7 +121,7 @@ private fun NotificationScreenPopulatedPreview() {
     FeelinTheme {
         NotificationScreen(
             uiState = NotificationUiState.populatedSample(),
-            onEditClick = {},
+            onBackClick = {},
             onTabClick = {},
             onNotificationClick = {},
             onDialogConfirmClick = {}
@@ -143,7 +143,7 @@ private fun NotificationScreenEmptyPreview() {
     FeelinTheme {
         NotificationScreen(
             uiState = NotificationUiState.emptySample(),
-            onEditClick = {},
+            onBackClick = {},
             onTabClick = {},
             onNotificationClick = {},
             onDialogConfirmClick = {}
@@ -165,7 +165,7 @@ private fun NotificationScreenReportPreview() {
     FeelinTheme {
         NotificationScreen(
             uiState = NotificationUiState.reportSample(),
-            onEditClick = {},
+            onBackClick = {},
             onTabClick = {},
             onNotificationClick = {},
             onDialogConfirmClick = {}
@@ -187,7 +187,7 @@ private fun NotificationScreenDeletedNoteDialogPreview() {
     FeelinTheme {
         NotificationScreen(
             uiState = NotificationUiState.deletedNoteDialogSample(),
-            onEditClick = {},
+            onBackClick = {},
             onTabClick = {},
             onNotificationClick = {},
             onDialogConfirmClick = {}

--- a/app/src/main/java/com/lyrics/feelin/presentation/view/notification/NotificationUiState.kt
+++ b/app/src/main/java/com/lyrics/feelin/presentation/view/notification/NotificationUiState.kt
@@ -1,8 +1,6 @@
 package com.lyrics.feelin.presentation.view.notification
 
-import androidx.annotation.DrawableRes
 import androidx.compose.runtime.Immutable
-import com.lyrics.feelin.R
 
 enum class NotificationTab(val label: String) {
     MY_NEWS("내 소식"),
@@ -14,8 +12,7 @@ data class NotificationItemUiModel(
     val id: Long,
     val message: String,
     val timeLabel: String,
-    // FIXME(@이대근): 고정 리소스 사용하면 안됨, 네트워크 이미지를 표현해야 함
-    @param:DrawableRes val thumbnailRes: Int,
+    val imageUrl: String?,
     val isRead: Boolean,
 )
 
@@ -34,49 +31,49 @@ data class NotificationUiState(
                         id = 1L,
                         message = "새 노트에 좋아요가 달렸어요.",
                         timeLabel = "방금 전",
-                        thumbnailRes = R.drawable.lyrics_background_img00,
+                        imageUrl = "https://picsum.photos/seed/feelin-notification-1/72/72",
                         isRead = false,
                     ),
                     NotificationItemUiModel(
                         id = 2L,
                         message = "친구가 당신의 노트에 댓글을 남겼어요.",
                         timeLabel = "10분 전",
-                        thumbnailRes = R.drawable.lyrics_background_img01,
+                        imageUrl = "https://picsum.photos/seed/feelin-notification-2/72/72",
                         isRead = false,
                     ),
                     NotificationItemUiModel(
                         id = 3L,
                         message = "즐겨찾는 아티스트의 새 글이 올라왔어요.",
                         timeLabel = "1시간 전",
-                        thumbnailRes = R.drawable.lyrics_background_img02,
+                        imageUrl = "https://picsum.photos/seed/feelin-notification-3/72/72",
                         isRead = true,
                     ),
                     NotificationItemUiModel(
                         id = 4L,
                         message = "내가 저장한 노트의 반응을 확인해보세요.",
                         timeLabel = "어제",
-                        thumbnailRes = R.drawable.lyrics_background_img03,
+                        imageUrl = "https://picsum.photos/seed/feelin-notification-4/72/72",
                         isRead = true,
                     ),
                     NotificationItemUiModel(
                         id = 5L,
                         message = "노트에 새로운 공감이 추가되었어요.",
                         timeLabel = "어제",
-                        thumbnailRes = R.drawable.lyrics_background_img04,
+                        imageUrl = "https://picsum.photos/seed/feelin-notification-5/72/72",
                         isRead = true,
                     ),
                     NotificationItemUiModel(
                         id = 6L,
                         message = "팔로우 중인 사용자가 새 노트를 남겼어요.",
                         timeLabel = "2일 전",
-                        thumbnailRes = R.drawable.lyrics_background_img05,
+                        imageUrl = "https://picsum.photos/seed/feelin-notification-6/72/72",
                         isRead = true,
                     ),
                     NotificationItemUiModel(
                         id = 7L,
                         message = "이전 알림을 다시 확인해보세요.",
                         timeLabel = "2일 전",
-                        thumbnailRes = R.drawable.lyrics_background_img06,
+                        imageUrl = "https://picsum.photos/seed/feelin-notification-7/72/72",
                         isRead = true,
                     ),
                 ),
@@ -100,14 +97,14 @@ data class NotificationUiState(
                         id = 101L,
                         message = "신고가 접수된 노트예요.\n반복되는 비방 표현이 포함되어 있어요.\n운영팀 확인 후 삭제되었어요.",
                         timeLabel = "3시간 전",
-                        thumbnailRes = R.drawable.lyrics_background_img00,
+                        imageUrl = "https://picsum.photos/seed/feelin-report-1/72/72",
                         isRead = true,
                     ),
                     NotificationItemUiModel(
                         id = 102L,
                         message = "최근 활동 알림",
                         timeLabel = "3시간 전",
-                        thumbnailRes = R.drawable.lyrics_background_img01,
+                        imageUrl = "https://picsum.photos/seed/feelin-report-2/72/72",
                         isRead = true,
                     ),
                 ),

--- a/app/src/main/java/com/lyrics/feelin/presentation/view/notification/NotificationUiState.kt
+++ b/app/src/main/java/com/lyrics/feelin/presentation/view/notification/NotificationUiState.kt
@@ -1,0 +1,122 @@
+package com.lyrics.feelin.presentation.view.notification
+
+import androidx.annotation.DrawableRes
+import androidx.compose.runtime.Immutable
+import com.lyrics.feelin.R
+
+enum class NotificationTab(val label: String) {
+    MY_NEWS("내 소식"),
+    ALL("전체"),
+}
+
+@Immutable
+data class NotificationItemUiModel(
+    val id: Long,
+    val message: String,
+    val timeLabel: String,
+    // FIXME(@이대근): 고정 리소스 사용하면 안됨, 네트워크 이미지를 표현해야 함
+    @param:DrawableRes val thumbnailRes: Int,
+    val isRead: Boolean,
+)
+
+@Immutable
+data class NotificationUiState(
+    val selectedTab: NotificationTab = NotificationTab.MY_NEWS,
+    val items: List<NotificationItemUiModel> = emptyList(),
+    val isDeletedNoteDialogVisible: Boolean = false,
+) {
+    companion object {
+        fun populatedSample(): NotificationUiState {
+            return NotificationUiState(
+                selectedTab = NotificationTab.MY_NEWS,
+                items = listOf(
+                    NotificationItemUiModel(
+                        id = 1L,
+                        message = "새 노트에 좋아요가 달렸어요.",
+                        timeLabel = "방금 전",
+                        thumbnailRes = R.drawable.lyrics_background_img00,
+                        isRead = false,
+                    ),
+                    NotificationItemUiModel(
+                        id = 2L,
+                        message = "친구가 당신의 노트에 댓글을 남겼어요.",
+                        timeLabel = "10분 전",
+                        thumbnailRes = R.drawable.lyrics_background_img01,
+                        isRead = false,
+                    ),
+                    NotificationItemUiModel(
+                        id = 3L,
+                        message = "즐겨찾는 아티스트의 새 글이 올라왔어요.",
+                        timeLabel = "1시간 전",
+                        thumbnailRes = R.drawable.lyrics_background_img02,
+                        isRead = true,
+                    ),
+                    NotificationItemUiModel(
+                        id = 4L,
+                        message = "내가 저장한 노트의 반응을 확인해보세요.",
+                        timeLabel = "어제",
+                        thumbnailRes = R.drawable.lyrics_background_img03,
+                        isRead = true,
+                    ),
+                    NotificationItemUiModel(
+                        id = 5L,
+                        message = "노트에 새로운 공감이 추가되었어요.",
+                        timeLabel = "어제",
+                        thumbnailRes = R.drawable.lyrics_background_img04,
+                        isRead = true,
+                    ),
+                    NotificationItemUiModel(
+                        id = 6L,
+                        message = "팔로우 중인 사용자가 새 노트를 남겼어요.",
+                        timeLabel = "2일 전",
+                        thumbnailRes = R.drawable.lyrics_background_img05,
+                        isRead = true,
+                    ),
+                    NotificationItemUiModel(
+                        id = 7L,
+                        message = "이전 알림을 다시 확인해보세요.",
+                        timeLabel = "2일 전",
+                        thumbnailRes = R.drawable.lyrics_background_img06,
+                        isRead = true,
+                    ),
+                ),
+                isDeletedNoteDialogVisible = false,
+            )
+        }
+
+        fun emptySample(): NotificationUiState {
+            return NotificationUiState(
+                selectedTab = NotificationTab.ALL,
+                items = emptyList(),
+                isDeletedNoteDialogVisible = false,
+            )
+        }
+
+        fun reportSample(): NotificationUiState {
+            return NotificationUiState(
+                selectedTab = NotificationTab.ALL,
+                items = listOf(
+                    NotificationItemUiModel(
+                        id = 101L,
+                        message = "신고가 접수된 노트예요.\n반복되는 비방 표현이 포함되어 있어요.\n운영팀 확인 후 삭제되었어요.",
+                        timeLabel = "3시간 전",
+                        thumbnailRes = R.drawable.lyrics_background_img00,
+                        isRead = true,
+                    ),
+                    NotificationItemUiModel(
+                        id = 102L,
+                        message = "최근 활동 알림",
+                        timeLabel = "3시간 전",
+                        thumbnailRes = R.drawable.lyrics_background_img01,
+                        isRead = true,
+                    ),
+                ),
+                isDeletedNoteDialogVisible = false,
+            )
+        }
+
+        fun deletedNoteDialogSample(): NotificationUiState {
+            return populatedSample().copy(isDeletedNoteDialogVisible = true)
+        }
+    }
+}

--- a/app/src/main/java/com/lyrics/feelin/presentation/view/notification/NotificationViewModel.kt
+++ b/app/src/main/java/com/lyrics/feelin/presentation/view/notification/NotificationViewModel.kt
@@ -1,0 +1,29 @@
+package com.lyrics.feelin.presentation.view.notification
+
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+@HiltViewModel
+class NotificationViewModel @Inject constructor() : ViewModel() {
+
+    private val myNewsItems = NotificationUiState.populatedSample().items
+
+    private val _uiState = MutableStateFlow(
+        NotificationUiState(items = myNewsItems)
+    )
+    val uiState: StateFlow<NotificationUiState> = _uiState.asStateFlow()
+
+    fun selectTab(tab: NotificationTab) {
+        _uiState.value = _uiState.value.copy(
+            selectedTab = tab,
+            items = when (tab) {
+                NotificationTab.MY_NEWS -> myNewsItems
+                NotificationTab.ALL -> emptyList()
+            }
+        )
+    }
+}

--- a/app/src/main/java/com/lyrics/feelin/presentation/view/notification/component/NotificationEmptyState.kt
+++ b/app/src/main/java/com/lyrics/feelin/presentation/view/notification/component/NotificationEmptyState.kt
@@ -1,0 +1,47 @@
+package com.lyrics.feelin.presentation.view.notification.component
+
+import android.content.res.Configuration
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import com.lyrics.feelin.presentation.designsystem.theme.FeelinTheme
+import com.lyrics.feelin.presentation.designsystem.theme.FeelinTypography
+import com.lyrics.feelin.presentation.designsystem.theme.LocalFeelinColors
+
+@Composable
+fun NotificationEmptyState(
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier = modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = "새로운 알림이 없어요",
+            style = FeelinTypography.body3,
+            color = LocalFeelinColors.current.gray09,
+            textAlign = TextAlign.Center
+        )
+    }
+}
+
+@Preview(name = "Notification Empty State - Light", showBackground = true)
+@Preview(
+    name = "Notification Empty State - Dark",
+    showBackground = true,
+    uiMode = Configuration.UI_MODE_NIGHT_YES
+)
+@Composable
+private fun NotificationEmptyStatePreview() {
+    FeelinTheme {
+        Box(modifier = Modifier.background(LocalFeelinColors.current.backgroundPrimary)) {
+            NotificationEmptyState()
+        }
+    }
+}

--- a/app/src/main/java/com/lyrics/feelin/presentation/view/notification/component/NotificationListItem.kt
+++ b/app/src/main/java/com/lyrics/feelin/presentation/view/notification/component/NotificationListItem.kt
@@ -1,0 +1,146 @@
+package com.lyrics.feelin.presentation.view.notification.component
+
+import android.content.res.Configuration
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.lyrics.feelin.R
+import com.lyrics.feelin.presentation.designsystem.theme.FeelinTheme
+import com.lyrics.feelin.presentation.designsystem.theme.FeelinTypography
+import com.lyrics.feelin.presentation.designsystem.theme.LocalFeelinColors
+import com.lyrics.feelin.presentation.view.notification.NotificationItemUiModel
+
+private const val THUMBNAIL_ALPHA_READ = 0.5f
+
+@Composable
+fun NotificationListItem(
+    item: NotificationItemUiModel,
+    onClick: (Long) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val feelinColors = LocalFeelinColors.current
+
+    val messageColor = if (item.isRead) feelinColors.gray04 else feelinColors.gray09
+    val timeColor = if (item.isRead) feelinColors.gray02 else feelinColors.gray03
+    val thumbnailAlpha = if (item.isRead) THUMBNAIL_ALPHA_READ else 1f
+
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .clickable { onClick(item.id) }
+            .padding(horizontal = 20.dp, vertical = 20.dp),
+        verticalAlignment = Alignment.Top
+    ) {
+        // FIXME(@이대근): 고정 리소스 사용하면 안됨, 네트워크 이미지를 표현해야 함.
+        Image(
+            painter = painterResource(id = item.thumbnailRes),
+            contentDescription = null,
+            contentScale = ContentScale.Crop,
+            modifier = Modifier
+                .size(36.dp)
+                .alpha(thumbnailAlpha)
+                .clip(CircleShape)
+        )
+
+        Spacer(modifier = Modifier.width(12.dp))
+
+        Column(
+            modifier = Modifier.weight(1f)
+        ) {
+            Text(
+                text = item.message,
+                style = FeelinTypography.body2,
+                color = messageColor
+            )
+
+            Spacer(modifier = Modifier.height(6.dp))
+
+            Text(
+                text = item.timeLabel,
+                style = FeelinTypography.caption2,
+                color = timeColor
+            )
+        }
+
+        if (!item.isRead) {
+            Spacer(modifier = Modifier.width(8.dp))
+            Box(
+                modifier = Modifier
+                    .size(4.dp)
+                    .background(color = feelinColors.point, shape = CircleShape)
+                    .align(Alignment.CenterVertically)
+            )
+        }
+    }
+}
+
+@Preview(name = "Notification List Item - Light", showBackground = true)
+@Preview(
+    name = "Notification List Item - Dark",
+    showBackground = true,
+    uiMode = Configuration.UI_MODE_NIGHT_YES
+)
+@Composable
+private fun NotificationListItemPreview() {
+    FeelinTheme {
+        val colors = LocalFeelinColors.current
+        Column(
+            modifier = Modifier
+                .background(colors.backgroundPrimary)
+        ) {
+            NotificationListItem(
+                item = NotificationItemUiModel(
+                    id = 1L,
+                    message = "누군가 내 노트에 좋아요를 남겼어요.",
+                    timeLabel = "방금 전",
+                    thumbnailRes = R.drawable.lyrics_background_img00,
+                    isRead = false
+                ),
+                onClick = {}
+            )
+            NotificationListItem(
+                item = NotificationItemUiModel(
+                    id = 2L,
+                    message = "누군가 내 노트에 좋아요를 남겼어요.",
+                    timeLabel = "3시간 전",
+                    thumbnailRes = R.drawable.lyrics_background_img00,
+                    isRead = true
+                ),
+                onClick = {}
+            )
+            val longMsg = "신고하신 노트가 삭제 처리되었어요.\n\n" +
+                "해당 노트는 운영 정책 위반으로 인해 삭제되었으며, " +
+                "더 이상 앱 내에서 노출되지 않습니다. 신고 접수해 주셔서 감사합니다."
+            NotificationListItem(
+                item = NotificationItemUiModel(
+                    id = 3L,
+                    message = longMsg,
+                    timeLabel = "1일 전",
+                    thumbnailRes = R.drawable.lyrics_background_img00,
+                    isRead = false
+                ),
+                onClick = {}
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/lyrics/feelin/presentation/view/notification/component/NotificationListItem.kt
+++ b/app/src/main/java/com/lyrics/feelin/presentation/view/notification/component/NotificationListItem.kt
@@ -1,13 +1,13 @@
 package com.lyrics.feelin.presentation.view.notification.component
 
 import android.content.res.Configuration
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -21,9 +21,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import coil3.compose.AsyncImage
 import com.lyrics.feelin.R
 import com.lyrics.feelin.presentation.designsystem.theme.FeelinTheme
 import com.lyrics.feelin.presentation.designsystem.theme.FeelinTypography
@@ -51,16 +53,34 @@ fun NotificationListItem(
             .padding(horizontal = 20.dp, vertical = 20.dp),
         verticalAlignment = Alignment.Top
     ) {
-        // FIXME(@이대근): 고정 리소스 사용하면 안됨, 네트워크 이미지를 표현해야 함.
-        Image(
-            painter = painterResource(id = item.thumbnailRes),
-            contentDescription = null,
-            contentScale = ContentScale.Crop,
+        Box(
             modifier = Modifier
                 .size(36.dp)
-                .alpha(thumbnailAlpha)
-                .clip(CircleShape)
-        )
+        ) {
+            AsyncImage(
+                model = item.imageUrl,
+                contentDescription = null,
+                // MARK(@이대근): placeholder, error 다른 것으로 할 수 있는지 확인 2026.07.15.
+                placeholder = painterResource(id = R.drawable.lyrics_background_img00),
+                error = painterResource(id = R.drawable.lyrics_background_img00),
+                contentScale = ContentScale.Crop,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .alpha(thumbnailAlpha)
+                    .clip(CircleShape)
+                    .background(feelinColors.backgroundTertiary)
+            )
+
+            if (!item.isRead) {
+                Box(
+                    modifier = Modifier
+                        .size(4.dp)
+                        .background(color = feelinColors.point, shape = CircleShape)
+                        .align(Alignment.TopEnd)
+                        .testTag("notificationUnreadIndicator")
+                )
+            }
+        }
 
         Spacer(modifier = Modifier.width(12.dp))
 
@@ -73,22 +93,12 @@ fun NotificationListItem(
                 color = messageColor
             )
 
-            Spacer(modifier = Modifier.height(6.dp))
+            Spacer(modifier = Modifier.height(4.dp))
 
             Text(
                 text = item.timeLabel,
                 style = FeelinTypography.caption2,
                 color = timeColor
-            )
-        }
-
-        if (!item.isRead) {
-            Spacer(modifier = Modifier.width(8.dp))
-            Box(
-                modifier = Modifier
-                    .size(4.dp)
-                    .background(color = feelinColors.point, shape = CircleShape)
-                    .align(Alignment.CenterVertically)
             )
         }
     }
@@ -113,7 +123,7 @@ private fun NotificationListItemPreview() {
                     id = 1L,
                     message = "누군가 내 노트에 좋아요를 남겼어요.",
                     timeLabel = "방금 전",
-                    thumbnailRes = R.drawable.lyrics_background_img00,
+                    imageUrl = "https://picsum.photos/seed/feelin-preview-unread/72/72",
                     isRead = false
                 ),
                 onClick = {}
@@ -123,7 +133,7 @@ private fun NotificationListItemPreview() {
                     id = 2L,
                     message = "누군가 내 노트에 좋아요를 남겼어요.",
                     timeLabel = "3시간 전",
-                    thumbnailRes = R.drawable.lyrics_background_img00,
+                    imageUrl = "https://picsum.photos/seed/feelin-preview-read/72/72",
                     isRead = true
                 ),
                 onClick = {}
@@ -136,7 +146,7 @@ private fun NotificationListItemPreview() {
                     id = 3L,
                     message = longMsg,
                     timeLabel = "1일 전",
-                    thumbnailRes = R.drawable.lyrics_background_img00,
+                    imageUrl = "https://picsum.photos/seed/feelin-preview-report/72/72",
                     isRead = false
                 ),
                 onClick = {}

--- a/app/src/test/java/com/lyrics/feelin/presentation/view/notification/NotificationViewModelTest.kt
+++ b/app/src/test/java/com/lyrics/feelin/presentation/view/notification/NotificationViewModelTest.kt
@@ -1,0 +1,45 @@
+package com.lyrics.feelin.presentation.view.notification
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class NotificationViewModelTest {
+
+    private lateinit var viewModel: NotificationViewModel
+
+    @Before
+    fun setUp() {
+        viewModel = NotificationViewModel()
+    }
+
+    @Test
+    fun initialStateShowsMyNews() {
+        val state = viewModel.uiState.value
+
+        assertEquals(NotificationTab.MY_NEWS, state.selectedTab)
+        assertTrue(state.items.isNotEmpty())
+    }
+
+    @Test
+    fun selectAllShowsEmptyState() {
+        viewModel.selectTab(NotificationTab.ALL)
+
+        val state = viewModel.uiState.value
+
+        assertEquals(NotificationTab.ALL, state.selectedTab)
+        assertTrue(state.items.isEmpty())
+    }
+
+    @Test
+    fun switchingBackRestoresMyNewsItems() {
+        viewModel.selectTab(NotificationTab.ALL)
+        viewModel.selectTab(NotificationTab.MY_NEWS)
+
+        val state = viewModel.uiState.value
+
+        assertEquals(NotificationTab.MY_NEWS, state.selectedTab)
+        assertTrue(state.items.isNotEmpty())
+    }
+}


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added

## What kind of change does this PR introduce?
- Implement design

# What is the current behavior?
홈 화면의 알림 아이콘에 이동 동작이 연결되어 있지 않고, 알림 목록을 보여주는 화면과 Navigation 목적지가 없습니다.

# What is the new behavior (if this is a feature change)?
알림 화면을 구현하고 홈 화면 및 Navigation graph에 연결했습니다.

- 뒤로가기 버튼과 중앙 정렬된 제목을 포함한 상단 앱바
- `내 소식`, `전체` 탭과 탭별 샘플 상태
- 알림 목록과 빈 상태 화면
- 읽음 여부에 따른 텍스트, 썸네일, 안 읽음 표시
- URL 이미지 로딩과 기본 placeholder
- 삭제된 노트 상태를 위한 안내 다이얼로그 UI
- Hilt `NotificationViewModel`과 `StateFlow` 기반 상태 관리
- 홈 알림 아이콘에서 알림 화면으로 이동하는 Navigation 연결
- ViewModel 단위 테스트와 Compose UI 테스트

서버 및 Repository를 통한 실제 알림 조회와 알림 항목 클릭 후 상세 화면 이동은 이번 작업 범위에서 제외했습니다.

## Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
아니요. 기존 기능에 영향을 주는 breaking change는 없습니다.

## ScreenShots (If needed)

### Light mode
<p>
  <img width="300" alt="Screenshot_20260715_231014_ DEV  Feelin" src="https://github.com/user-attachments/assets/487ec307-3b51-402c-84aa-b0aafe0de05b" />
  <img width="300" alt="Screenshot_20260715_231017_ DEV  Feelin" src="https://github.com/user-attachments/assets/d0fb7f87-3acb-4a9b-831d-235d1aa9a287" />
</p>

### Dark mode
<p>
  <img width="300" alt="Screenshot_20260715_231024_ DEV  Feelin" src="https://github.com/user-attachments/assets/efaee562-a952-41a2-a619-f56dd6277102" />
  <img width="300" alt="Screenshot_20260715_231027_ DEV  Feelin" src="https://github.com/user-attachments/assets/6bc45077-c230-407c-9811-12ca70d0f5ef" />
</p>

## Other information:

### AI Agent
다음 항목을 검증했습니다.

- `./gradlew :app:testDevDebugUnitTest`
- `./gradlew :app:connectedDevDebugAndroidTest` (15 tests)
- `./gradlew detekt`
- `./gradlew :app:assembleDebug`
- 에뮬레이터에서 알림 화면 진입, 탭 전환, 빈 상태, 뒤로가기 동작 확인

### User
지금은 알림 화면 이동이 홈 화면에서만 있는데, 실제 구현에서는 마이페이지에서의 이동과 아티스트 화면에서의 이동(요구사항이 약간 다름)이 있습니다. 이는 실제 기능 연동시에 같이 연동하겠습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a notifications screen accessible from the home screen.
  * Added “My News” and “All” notification tabs.
  * Added empty-state messaging, unread indicators, notification item interactions, and deleted-note confirmation dialog.
  * Added back navigation from the notifications screen.

* **Tests**
  * Added coverage for notification display, tab switching, empty states, dividers, and read/unread indicators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->