### PR TITLE
SCRUM-234 design: Add user gender and birth year edit screen

### DIFF
--- a/app/src/androidTest/java/com/lyrics/feelin/core/designsystem/component/BirthYearPickerDarkThemeTest.kt
+++ b/app/src/androidTest/java/com/lyrics/feelin/core/designsystem/component/BirthYearPickerDarkThemeTest.kt
@@ -20,16 +20,10 @@ class BirthYearPickerDarkThemeTest {
 
     @Test
     fun numberPickerUsesLightTextColorInNightMode() {
-        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
-
-        val nightConfig = Configuration(context.resources.configuration).apply {
-            uiMode = (uiMode and Configuration.UI_MODE_NIGHT_MASK.inv()) or Configuration.UI_MODE_NIGHT_YES
-        }
-        val nightContext = context.createConfigurationContext(nightConfig)
-        val themedContext = ContextThemeWrapper(nightContext, R.style.Theme_Feelin)
-
-        val picker = NumberPicker(themedContext)
-        val inputText = findEditText(picker)
+        val inputText = createPickerInputText(
+            uiMode = Configuration.UI_MODE_NIGHT_YES,
+            styleRes = R.style.Theme_Feelin
+        )
 
         assertTrue(
             "NumberPicker text color should be light in night mode, but was #${Integer.toHexString(inputText.currentTextColor)}",
@@ -39,21 +33,59 @@ class BirthYearPickerDarkThemeTest {
 
     @Test
     fun numberPickerUsesDarkTextColorInLightMode() {
-        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
-
-        val lightConfig = Configuration(context.resources.configuration).apply {
-            uiMode = (uiMode and Configuration.UI_MODE_NIGHT_MASK.inv()) or Configuration.UI_MODE_NIGHT_NO
-        }
-        val lightContext = context.createConfigurationContext(lightConfig)
-        val themedContext = ContextThemeWrapper(lightContext, R.style.Theme_Feelin)
-
-        val picker = NumberPicker(themedContext)
-        val inputText = findEditText(picker)
+        val inputText = createPickerInputText(
+            uiMode = Configuration.UI_MODE_NIGHT_NO,
+            styleRes = R.style.Theme_Feelin
+        )
 
         assertTrue(
             "NumberPicker text color should be dark in light mode, but was #${Integer.toHexString(inputText.currentTextColor)}",
             !isLightColor(inputText.currentTextColor)
         )
+    }
+
+    /**
+     * 온보딩처럼 Compose에서 라이트를 강제하는 화면을 모사합니다.
+     * 시스템이 다크 모드여도 명시적 라이트 테마를 쓰면 피커 글자색이 어두워야 합니다.
+     */
+    @Test
+    fun numberPickerWithExplicitLightThemeIgnoresSystemNightMode() {
+        val inputText = createPickerInputText(
+            uiMode = Configuration.UI_MODE_NIGHT_YES,
+            styleRes = R.style.Theme_Feelin_Light
+        )
+
+        assertTrue(
+            "NumberPicker with explicit light theme should use dark text even in night mode, " +
+                "but was #${Integer.toHexString(inputText.currentTextColor)}",
+            !isLightColor(inputText.currentTextColor)
+        )
+    }
+
+    @Test
+    fun numberPickerWithExplicitDarkThemeIgnoresSystemLightMode() {
+        val inputText = createPickerInputText(
+            uiMode = Configuration.UI_MODE_NIGHT_NO,
+            styleRes = R.style.Theme_Feelin_Dark
+        )
+
+        assertTrue(
+            "NumberPicker with explicit dark theme should use light text even in light mode, " +
+                "but was #${Integer.toHexString(inputText.currentTextColor)}",
+            isLightColor(inputText.currentTextColor)
+        )
+    }
+
+    private fun createPickerInputText(uiMode: Int, styleRes: Int): EditText {
+        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+
+        val config = Configuration(context.resources.configuration).apply {
+            this.uiMode = (this.uiMode and Configuration.UI_MODE_NIGHT_MASK.inv()) or uiMode
+        }
+        val configContext = context.createConfigurationContext(config)
+        val themedContext = ContextThemeWrapper(configContext, styleRes)
+
+        return findEditText(NumberPicker(themedContext))
     }
 
     private fun findEditText(picker: NumberPicker): EditText {

--- a/app/src/androidTest/java/com/lyrics/feelin/core/designsystem/component/BirthYearPickerDarkThemeTest.kt
+++ b/app/src/androidTest/java/com/lyrics/feelin/core/designsystem/component/BirthYearPickerDarkThemeTest.kt
@@ -1,0 +1,71 @@
+package com.lyrics.feelin.core.designsystem.component
+
+import android.content.res.Configuration
+import android.graphics.Color
+import android.widget.EditText
+import android.widget.NumberPicker
+import androidx.appcompat.view.ContextThemeWrapper
+import androidx.test.core.app.ApplicationProvider
+import com.lyrics.feelin.R
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * [FeelinBirthYearPicker]가 사용하는 네이티브 [NumberPicker]가 다크모드에서 밝은 글자색으로 그려지는지 검증합니다.
+ *
+ * 배경: 앱 테마에 values-night 변형이 없을 때 다크모드에서 피커 숫자가 어두운 색으로 렌더링되어 보이지 않는 문제가 있었습니다.
+ * (관련 이슈: #44 - theme.xml 다크모드 미대응)
+ */
+class BirthYearPickerDarkThemeTest {
+
+    @Test
+    fun numberPickerUsesLightTextColorInNightMode() {
+        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+
+        val nightConfig = Configuration(context.resources.configuration).apply {
+            uiMode = (uiMode and Configuration.UI_MODE_NIGHT_MASK.inv()) or Configuration.UI_MODE_NIGHT_YES
+        }
+        val nightContext = context.createConfigurationContext(nightConfig)
+        val themedContext = ContextThemeWrapper(nightContext, R.style.Theme_Feelin)
+
+        val picker = NumberPicker(themedContext)
+        val inputText = findEditText(picker)
+
+        assertTrue(
+            "NumberPicker text color should be light in night mode, but was #${Integer.toHexString(inputText.currentTextColor)}",
+            isLightColor(inputText.currentTextColor)
+        )
+    }
+
+    @Test
+    fun numberPickerUsesDarkTextColorInLightMode() {
+        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+
+        val lightConfig = Configuration(context.resources.configuration).apply {
+            uiMode = (uiMode and Configuration.UI_MODE_NIGHT_MASK.inv()) or Configuration.UI_MODE_NIGHT_NO
+        }
+        val lightContext = context.createConfigurationContext(lightConfig)
+        val themedContext = ContextThemeWrapper(lightContext, R.style.Theme_Feelin)
+
+        val picker = NumberPicker(themedContext)
+        val inputText = findEditText(picker)
+
+        assertTrue(
+            "NumberPicker text color should be dark in light mode, but was #${Integer.toHexString(inputText.currentTextColor)}",
+            !isLightColor(inputText.currentTextColor)
+        )
+    }
+
+    private fun findEditText(picker: NumberPicker): EditText {
+        for (i in 0 until picker.childCount) {
+            val child = picker.getChildAt(i)
+            if (child is EditText) return child
+        }
+        error("NumberPicker should contain an internal EditText")
+    }
+
+    private fun isLightColor(color: Int): Boolean {
+        val luminance = (0.299 * Color.red(color) + 0.587 * Color.green(color) + 0.114 * Color.blue(color)) / 255.0
+        return luminance > 0.5
+    }
+}

--- a/app/src/androidTest/java/com/lyrics/feelin/core/designsystem/component/GenderBirthYearComponentsTest.kt
+++ b/app/src/androidTest/java/com/lyrics/feelin/core/designsystem/component/GenderBirthYearComponentsTest.kt
@@ -1,0 +1,72 @@
+package com.lyrics.feelin.core.designsystem.component
+
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.assertHeightIsEqualTo
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import com.lyrics.feelin.R
+import com.lyrics.feelin.presentation.designsystem.theme.FeelinTheme
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+
+class GenderBirthYearComponentsTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun genderButtonUsesFigmaHeight() {
+        composeRule.setContent {
+            FeelinTheme {
+                FeelinGenderButton(
+                    text = "여성",
+                    iconRes = R.drawable.ic_gender_female_active,
+                    selected = true,
+                    onClick = {},
+                    modifier = Modifier.testTag("genderButton"),
+                )
+            }
+        }
+
+        composeRule.onNodeWithTag("genderButton").assertHeightIsEqualTo(204.dp)
+    }
+
+    @Test
+    fun birthYearPickerUsesFigmaHeight() {
+        composeRule.setContent {
+            FeelinTheme {
+                FeelinBirthYearPicker(
+                    value = "2000년",
+                    placeholder = "출생 연도를 입력해주세요",
+                    onValueChange = {},
+                    modifier = Modifier.testTag("birthYearPicker"),
+                )
+            }
+        }
+
+        composeRule.onNodeWithTag("birthYearPicker").assertHeightIsEqualTo(52.dp)
+    }
+
+    @Test
+    fun birthYearPickerKeepsSuffixedInitialValueOnConfirm() {
+        var selectedYear = ""
+        composeRule.setContent {
+            FeelinTheme {
+                FeelinBirthYearPicker(
+                    value = "2000년",
+                    placeholder = "출생 연도를 입력해주세요",
+                    onValueChange = { selectedYear = it },
+                )
+            }
+        }
+
+        composeRule.onNodeWithText("2000년").performClick()
+        composeRule.onNodeWithText("확인").performClick()
+
+        composeRule.runOnIdle { assertEquals("2000", selectedYear) }
+    }
+}

--- a/app/src/androidTest/java/com/lyrics/feelin/presentation/view/mypage/userinfo/EditGenderBirthYearScreenTest.kt
+++ b/app/src/androidTest/java/com/lyrics/feelin/presentation/view/mypage/userinfo/EditGenderBirthYearScreenTest.kt
@@ -1,0 +1,72 @@
+package com.lyrics.feelin.presentation.view.mypage.userinfo
+
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import com.lyrics.feelin.presentation.designsystem.theme.FeelinTheme
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+class EditGenderBirthYearScreenTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun initialDummyValuesAreShownAndSaveIsDisabled() {
+        composeRule.setContent {
+            FeelinTheme {
+                EditGenderBirthYearScreen(
+                    onBackClick = {},
+                    onSaveClick = {},
+                )
+            }
+        }
+
+        composeRule.onNodeWithText("여성").assertIsDisplayed()
+        composeRule.onNodeWithText("2000년").assertIsDisplayed()
+        composeRule.onNodeWithText("회원 정보 저장").assertIsNotEnabled()
+    }
+
+    @Test
+    fun changingGenderEnablesSaveAndInvokesCallback() {
+        var saveClicked = false
+        composeRule.setContent {
+            FeelinTheme {
+                EditGenderBirthYearScreen(
+                    onBackClick = {},
+                    onSaveClick = { saveClicked = true },
+                )
+            }
+        }
+
+        composeRule.onNodeWithText("남성").performClick()
+        composeRule.onNodeWithText("회원 정보 저장").assertIsEnabled().performClick()
+
+        composeRule.runOnIdle { assertTrue(saveClicked) }
+    }
+
+    @Test
+    fun dirtyBackShowsDiscardDialogAndLeavesOnConfirm() {
+        var backClicked = false
+        composeRule.setContent {
+            FeelinTheme {
+                EditGenderBirthYearScreen(
+                    onBackClick = { backClicked = true },
+                    onSaveClick = {},
+                )
+            }
+        }
+
+        composeRule.onNodeWithText("남성").performClick()
+        composeRule.onNodeWithContentDescription("Back").performClick()
+        composeRule.onNodeWithText("저장하지 않고 나가시겠어요?").assertIsDisplayed()
+        composeRule.onNodeWithText("나가기").performClick()
+
+        composeRule.runOnIdle { assertTrue(backClicked) }
+    }
+}

--- a/app/src/androidTest/java/com/lyrics/feelin/presentation/view/mypage/userinfo/UserInfoScreenTest.kt
+++ b/app/src/androidTest/java/com/lyrics/feelin/presentation/view/mypage/userinfo/UserInfoScreenTest.kt
@@ -1,0 +1,31 @@
+package com.lyrics.feelin.presentation.view.mypage.userinfo
+
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import com.lyrics.feelin.presentation.designsystem.theme.FeelinTheme
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+class UserInfoScreenTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun genderBirthYearRowInvokesNavigationCallback() {
+        var rowClicked = false
+        composeRule.setContent {
+            FeelinTheme {
+                UserInfoScreen(
+                    onBackClick = {},
+                    onGenderBirthYearClick = { rowClicked = true },
+                )
+            }
+        }
+
+        composeRule.onNodeWithText("여성ㆍ2000년").performClick()
+
+        composeRule.runOnIdle { assertTrue(rowClicked) }
+    }
+}

--- a/app/src/main/java/com/lyrics/feelin/core/designsystem/component/FeelinBirthYearPicker.kt
+++ b/app/src/main/java/com/lyrics/feelin/core/designsystem/component/FeelinBirthYearPicker.kt
@@ -54,9 +54,10 @@ fun FeelinBirthYearPicker(
     val startYear = 1900
     val years = (startYear..currentYear).toList()
 
-    var selectedYearIndex by remember {
+    val initialYearIndex = years.indexOf(value.removeSuffix("년").toIntOrNull())
+    var selectedYearIndex by remember(value) {
         mutableIntStateOf(
-            value.toIntOrNull()?.let { years.indexOf(it) } ?: years.indexOf(currentYear)
+            initialYearIndex.takeIf { it >= 0 } ?: years.indexOf(currentYear)
         )
     }
 
@@ -64,15 +65,15 @@ fun FeelinBirthYearPicker(
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .height(56.dp)
+                .height(52.dp)
                 .background(
                     color = if (isActivated) feelinColors.systemPressedBrand else feelinColors.gray00,
-                    shape = RoundedCornerShape(12.dp)
+                    shape = RoundedCornerShape(8.dp)
                 )
                 .border(
                     width = if (isActivated) 0.dp else 1.dp,
                     color = feelinColors.gray01,
-                    shape = RoundedCornerShape(12.dp)
+                    shape = RoundedCornerShape(8.dp)
                 )
                 .clickable { showDialog = true }
                 .padding(horizontal = 16.dp),

--- a/app/src/main/java/com/lyrics/feelin/core/designsystem/component/FeelinBirthYearPicker.kt
+++ b/app/src/main/java/com/lyrics/feelin/core/designsystem/component/FeelinBirthYearPicker.kt
@@ -1,5 +1,6 @@
 package com.lyrics.feelin.core.designsystem.component
 
+import android.view.ContextThemeWrapper
 import android.widget.NumberPicker
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -30,9 +31,11 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
+import com.lyrics.feelin.R
 import com.lyrics.feelin.core.designsystem.icon.CaretIcon
 import com.lyrics.feelin.presentation.designsystem.theme.FeelinTheme
 import com.lyrics.feelin.presentation.designsystem.theme.FeelinTypography
+import com.lyrics.feelin.presentation.designsystem.theme.LocalDarkTheme
 import com.lyrics.feelin.presentation.designsystem.theme.LocalFeelinColors
 import java.util.Calendar
 
@@ -44,6 +47,7 @@ fun FeelinBirthYearPicker(
     modifier: Modifier = Modifier
 ) {
     val feelinColors = LocalFeelinColors.current
+    val isDarkTheme = LocalDarkTheme.current
     var showDialog by remember { mutableStateOf(false) }
     val displayText = value.ifEmpty { placeholder }
     val isActivated = value.isNotEmpty()
@@ -114,7 +118,12 @@ fun FeelinBirthYearPicker(
                     ) {
                         AndroidView(
                             factory = { context ->
-                                NumberPicker(context).apply {
+                                // 네이티브 NumberPicker는 Compose 테마를 따르지 않으므로,
+                                // Compose의 다크 여부(LocalDarkTheme)에 맞는 명시적 테마로 감싼다.
+                                // 온보딩처럼 라이트를 강제하는 화면에서도 피커가 라이트로 그려진다.
+                                val pickerTheme =
+                                    if (isDarkTheme) R.style.Theme_Feelin_Dark else R.style.Theme_Feelin_Light
+                                NumberPicker(ContextThemeWrapper(context, pickerTheme)).apply {
                                     minValue = 0
                                     maxValue = years.size - 1
                                     displayedValues = years.map { it.toString() }.toTypedArray()

--- a/app/src/main/java/com/lyrics/feelin/core/designsystem/component/FeelinBirthYearPicker.kt
+++ b/app/src/main/java/com/lyrics/feelin/core/designsystem/component/FeelinBirthYearPicker.kt
@@ -79,7 +79,11 @@ fun FeelinBirthYearPicker(
                     color = feelinColors.gray01,
                     shape = RoundedCornerShape(8.dp)
                 )
-                .clickable { showDialog = true }
+                .clickable {
+                    // 이전에 취소한 임시 선택이 남지 않도록, 열 때마다 커밋된 값 기준으로 리셋한다.
+                    selectedYearIndex = initialYearIndex.takeIf { it >= 0 } ?: years.indexOf(currentYear)
+                    showDialog = true
+                }
                 .padding(horizontal = 16.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {

--- a/app/src/main/java/com/lyrics/feelin/core/designsystem/component/FeelinGenderButton.kt
+++ b/app/src/main/java/com/lyrics/feelin/core/designsystem/component/FeelinGenderButton.kt
@@ -39,20 +39,21 @@ fun FeelinGenderButton(
     Column(
         modifier = modifier
             .fillMaxWidth()
+            .height(204.dp)
             .background(
                 color = if (selected) feelinColors.systemPressedBrand else feelinColors.gray00,
-                shape = RoundedCornerShape(12.dp)
+                shape = RoundedCornerShape(8.dp)
             )
             .border(
                 width = if (selected) 0.dp else 1.dp,
                 color = feelinColors.gray01,
-                shape = RoundedCornerShape(12.dp)
+                shape = RoundedCornerShape(8.dp)
             )
             .clickable(
                 indication = null,
                 interactionSource = remember { MutableInteractionSource() }
             ) { onClick() }
-            .padding(vertical = 24.dp),
+            .padding(vertical = 22.dp),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         Icon(

--- a/app/src/main/java/com/lyrics/feelin/core/designsystem/component/FeelinGenderButton.kt
+++ b/app/src/main/java/com/lyrics/feelin/core/designsystem/component/FeelinGenderButton.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -39,7 +40,7 @@ fun FeelinGenderButton(
     Column(
         modifier = modifier
             .fillMaxWidth()
-            .height(204.dp)
+            .defaultMinSize(minHeight = 204.dp)
             .background(
                 color = if (selected) feelinColors.systemPressedBrand else feelinColors.gray00,
                 shape = RoundedCornerShape(8.dp)

--- a/app/src/main/java/com/lyrics/feelin/core/designsystem/component/FeelinNormalButton.kt
+++ b/app/src/main/java/com/lyrics/feelin/core/designsystem/component/FeelinNormalButton.kt
@@ -12,6 +12,8 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.lyrics.feelin.presentation.designsystem.theme.FeelinTheme
 import com.lyrics.feelin.presentation.designsystem.theme.FeelinTypography
+import com.lyrics.feelin.presentation.designsystem.theme.LightGray00
+import com.lyrics.feelin.presentation.designsystem.theme.LocalDarkTheme
 import com.lyrics.feelin.presentation.designsystem.theme.LocalFeelinColors
 
 /** 디자인시스템에 접미사가 없이 선언된 버튼입니다. */
@@ -22,6 +24,9 @@ fun FeelinNormalButton(
     modifier: Modifier = Modifier,
     onClick: () -> Unit = {},
 ) {
+    val feelinColors = LocalFeelinColors.current
+    val isDarkTheme = LocalDarkTheme.current
+
     Button(
         onClick = onClick,
         enabled = enabled,
@@ -30,14 +35,16 @@ fun FeelinNormalButton(
             .height(56.dp),
         shape = RoundedCornerShape(12.dp),
         colors = ButtonDefaults.buttonColors(
-            containerColor = LocalFeelinColors.current.systemActivate,
-            disabledContainerColor = LocalFeelinColors.current.systemDisable,
+            containerColor = feelinColors.systemActivate,
+            contentColor = LightGray00,
+            disabledContainerColor = feelinColors.systemDisable,
+            // Figma Button(709:5452): 라이트 disabled는 흰색, 다크 disabled는 gray04
+            disabledContentColor = if (isDarkTheme) feelinColors.gray04 else LightGray00,
         )
     ) {
         Text(
             text = text,
             style = FeelinTypography.title2,
-            color = LocalFeelinColors.current.gray00,
         )
     }
 }

--- a/app/src/main/java/com/lyrics/feelin/navigation/FeelinDestination.kt
+++ b/app/src/main/java/com/lyrics/feelin/navigation/FeelinDestination.kt
@@ -80,6 +80,7 @@ sealed class FeelinDestination(
     object MyPage : FeelinDestination(route = "my_page")
     object Setting : FeelinDestination(route = "setting")
     object UserInfo : FeelinDestination(route = "user_info")
+    object EditGenderBirthYear : FeelinDestination(route = "edit_gender_birth_year")
     object BlockedUsers : FeelinDestination(route = "blocked_users")
 
     object InternalWebView : FeelinDestination(

--- a/app/src/main/java/com/lyrics/feelin/navigation/FeelinNavHost.kt
+++ b/app/src/main/java/com/lyrics/feelin/navigation/FeelinNavHost.kt
@@ -57,6 +57,7 @@ import com.lyrics.feelin.presentation.view.mypage.MyPageViewModel
 import com.lyrics.feelin.presentation.view.mypage.blockedusers.BlockedUsersScreen
 import com.lyrics.feelin.presentation.view.mypage.blockedusers.BlockedUsersViewModel
 import com.lyrics.feelin.presentation.view.mypage.setting.SettingScreen
+import com.lyrics.feelin.presentation.view.mypage.userinfo.EditGenderBirthYearScreen
 import com.lyrics.feelin.presentation.view.mypage.userinfo.UserInfoScreen
 import com.lyrics.feelin.presentation.view.note.detail.NoteDetailScreen
 import com.lyrics.feelin.presentation.view.note.report.NoteReportScreen
@@ -448,8 +449,20 @@ private fun NavGraphBuilder.myPageNavGraph(navController: NavHostController) {
 
         composable(FeelinDestination.UserInfo.route) {
             MainScaffold(navController = navController, selectedIndex = 2) {
-                UserInfoScreen(onBackClick = { navController.popBackStack() })
+                UserInfoScreen(
+                    onBackClick = { navController.popBackStack() },
+                    onGenderBirthYearClick = {
+                        navController.navigate(FeelinDestination.EditGenderBirthYear.route)
+                    },
+                )
             }
+        }
+
+        composable(FeelinDestination.EditGenderBirthYear.route) {
+            EditGenderBirthYearScreen(
+                onBackClick = { navController.popBackStack() },
+                onSaveClick = { navController.popBackStack() },
+            )
         }
 
         composable(FeelinDestination.BlockedUsers.route) { backStackEntry ->

--- a/app/src/main/java/com/lyrics/feelin/presentation/view/mypage/userinfo/EditGenderBirthYearScreen.kt
+++ b/app/src/main/java/com/lyrics/feelin/presentation/view/mypage/userinfo/EditGenderBirthYearScreen.kt
@@ -17,6 +17,8 @@ import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -85,61 +87,65 @@ fun EditGenderBirthYearScreen(
                 .padding(horizontal = 20.dp)
                 .windowInsetsPadding(WindowInsets.navigationBars),
         ) {
-            Spacer(modifier = Modifier.height(36.dp))
-
-            Text(
-                text = "성별",
-                style = FeelinTypography.title2,
-                color = feelinColors.gray05,
-            )
-
-            Spacer(modifier = Modifier.height(12.dp))
-
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(14.dp),
+            Column(
+                modifier = Modifier
+                    .weight(1f)
+                    .verticalScroll(rememberScrollState()),
             ) {
-                FeelinGenderButton(
-                    text = "남성",
-                    iconRes = if (selectedGender == "male") {
-                        R.drawable.ic_gender_male_active
-                    } else {
-                        R.drawable.ic_gender_male_inactive
-                    },
-                    selected = selectedGender == "male",
-                    onClick = { selectedGender = "male" },
-                    modifier = Modifier.weight(1f),
+                Spacer(modifier = Modifier.height(36.dp))
+
+                Text(
+                    text = "성별",
+                    style = FeelinTypography.title2,
+                    color = feelinColors.gray05,
                 )
-                FeelinGenderButton(
-                    text = "여성",
-                    iconRes = if (selectedGender == "female") {
-                        R.drawable.ic_gender_female_active
-                    } else {
-                        R.drawable.ic_gender_female_inactive
-                    },
-                    selected = selectedGender == "female",
-                    onClick = { selectedGender = "female" },
-                    modifier = Modifier.weight(1f),
+
+                Spacer(modifier = Modifier.height(12.dp))
+
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(14.dp),
+                ) {
+                    FeelinGenderButton(
+                        text = "남성",
+                        iconRes = if (selectedGender == "male") {
+                            R.drawable.ic_gender_male_active
+                        } else {
+                            R.drawable.ic_gender_male_inactive
+                        },
+                        selected = selectedGender == "male",
+                        onClick = { selectedGender = "male" },
+                        modifier = Modifier.weight(1f),
+                    )
+                    FeelinGenderButton(
+                        text = "여성",
+                        iconRes = if (selectedGender == "female") {
+                            R.drawable.ic_gender_female_active
+                        } else {
+                            R.drawable.ic_gender_female_inactive
+                        },
+                        selected = selectedGender == "female",
+                        onClick = { selectedGender = "female" },
+                        modifier = Modifier.weight(1f),
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(24.dp))
+
+                Text(
+                    text = "출생 연도",
+                    style = FeelinTypography.title2,
+                    color = feelinColors.gray05,
+                )
+
+                Spacer(modifier = Modifier.height(12.dp))
+
+                FeelinBirthYearPicker(
+                    value = "${selectedBirthYear}년",
+                    placeholder = "출생 연도를 입력해주세요",
+                    onValueChange = { selectedBirthYear = it.removeSuffix("년") },
                 )
             }
-
-            Spacer(modifier = Modifier.height(24.dp))
-
-            Text(
-                text = "출생 연도",
-                style = FeelinTypography.title2,
-                color = feelinColors.gray05,
-            )
-
-            Spacer(modifier = Modifier.height(12.dp))
-
-            FeelinBirthYearPicker(
-                value = "${selectedBirthYear}년",
-                placeholder = "출생 연도를 입력해주세요",
-                onValueChange = { selectedBirthYear = it.removeSuffix("년") },
-            )
-
-            Spacer(modifier = Modifier.weight(1f))
 
             FeelinNormalButton(
                 text = "회원 정보 저장",

--- a/app/src/main/java/com/lyrics/feelin/presentation/view/mypage/userinfo/EditGenderBirthYearScreen.kt
+++ b/app/src/main/java/com/lyrics/feelin/presentation/view/mypage/userinfo/EditGenderBirthYearScreen.kt
@@ -1,0 +1,176 @@
+package com.lyrics.feelin.presentation.view.mypage.userinfo
+
+import android.content.res.Configuration
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.lyrics.feelin.R
+import com.lyrics.feelin.core.designsystem.component.FeelinBirthYearPicker
+import com.lyrics.feelin.core.designsystem.component.FeelinGenderButton
+import com.lyrics.feelin.core.designsystem.component.FeelinModalDialog
+import com.lyrics.feelin.core.designsystem.component.FeelinNormalButton
+import com.lyrics.feelin.core.designsystem.component.FeelinTopAppBarWithBack
+import com.lyrics.feelin.presentation.designsystem.theme.FeelinTheme
+import com.lyrics.feelin.presentation.designsystem.theme.FeelinTypography
+import com.lyrics.feelin.presentation.designsystem.theme.LocalFeelinColors
+
+private const val INITIAL_GENDER = "female"
+private const val INITIAL_BIRTH_YEAR = "2000"
+
+@Composable
+fun EditGenderBirthYearScreen(
+    onBackClick: () -> Unit,
+    onSaveClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val feelinColors = LocalFeelinColors.current
+    var selectedGender by rememberSaveable { mutableStateOf(INITIAL_GENDER) }
+    var selectedBirthYear by rememberSaveable { mutableStateOf(INITIAL_BIRTH_YEAR) }
+    var showExitDialog by rememberSaveable { mutableStateOf(false) }
+    val hasChanges = selectedGender != INITIAL_GENDER || selectedBirthYear != INITIAL_BIRTH_YEAR
+
+    val handleBack = {
+        if (hasChanges) {
+            showExitDialog = true
+        } else {
+            onBackClick()
+        }
+    }
+
+    BackHandler(onBack = handleBack)
+
+    Scaffold(
+        modifier = modifier
+            .fillMaxSize()
+            .windowInsetsPadding(WindowInsets.systemBars.only(WindowInsetsSides.Top))
+            .background(feelinColors.backgroundPrimary),
+        containerColor = feelinColors.backgroundPrimary,
+        contentWindowInsets = WindowInsets(0),
+        topBar = {
+            FeelinTopAppBarWithBack(
+                title = "회원 정보 수정",
+                onBackClick = handleBack,
+                centeredTitle = true,
+                showDivider = false,
+            )
+        },
+    ) { contentPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(contentPadding)
+                .padding(horizontal = 20.dp)
+                .windowInsetsPadding(WindowInsets.navigationBars),
+        ) {
+            Spacer(modifier = Modifier.height(36.dp))
+
+            Text(
+                text = "성별",
+                style = FeelinTypography.title2,
+                color = feelinColors.gray05,
+            )
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(14.dp),
+            ) {
+                FeelinGenderButton(
+                    text = "남성",
+                    iconRes = if (selectedGender == "male") {
+                        R.drawable.ic_gender_male_active
+                    } else {
+                        R.drawable.ic_gender_male_inactive
+                    },
+                    selected = selectedGender == "male",
+                    onClick = { selectedGender = "male" },
+                    modifier = Modifier.weight(1f),
+                )
+                FeelinGenderButton(
+                    text = "여성",
+                    iconRes = if (selectedGender == "female") {
+                        R.drawable.ic_gender_female_active
+                    } else {
+                        R.drawable.ic_gender_female_inactive
+                    },
+                    selected = selectedGender == "female",
+                    onClick = { selectedGender = "female" },
+                    modifier = Modifier.weight(1f),
+                )
+            }
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            Text(
+                text = "출생 연도",
+                style = FeelinTypography.title2,
+                color = feelinColors.gray05,
+            )
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            FeelinBirthYearPicker(
+                value = "${selectedBirthYear}년",
+                placeholder = "출생 연도를 입력해주세요",
+                onValueChange = { selectedBirthYear = it.removeSuffix("년") },
+            )
+
+            Spacer(modifier = Modifier.weight(1f))
+
+            FeelinNormalButton(
+                text = "회원 정보 저장",
+                enabled = hasChanges,
+                onClick = onSaveClick,
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+        }
+    }
+
+    if (showExitDialog) {
+        FeelinModalDialog(
+            title = "저장하지 않고 나가시겠어요?",
+            description = null,
+            confirmButtonText = "나가기",
+            onConfirmButtonClick = onBackClick,
+            dismissButtonText = "취소",
+            onDismissButtonClick = { showExitDialog = false },
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Preview(showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+private fun EditGenderBirthYearScreenPreview() {
+    FeelinTheme {
+        EditGenderBirthYearScreen(
+            onBackClick = {},
+            onSaveClick = {},
+        )
+    }
+}

--- a/app/src/main/java/com/lyrics/feelin/presentation/view/mypage/userinfo/UserInfoScreen.kt
+++ b/app/src/main/java/com/lyrics/feelin/presentation/view/mypage/userinfo/UserInfoScreen.kt
@@ -34,6 +34,7 @@ import com.lyrics.feelin.presentation.view.mypage.component.UserLoginInfoItem
 @Composable
 fun UserInfoScreen(
     onBackClick: () -> Unit,
+    onGenderBirthYearClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val feelinColors = LocalFeelinColors.current
@@ -78,7 +79,10 @@ fun UserInfoScreen(
             UserInfoCategoryDivider()
 
             InnerTitle(title = "성별 및 출생 년도")
-            SettingMenuItem("${gender}ㆍ${birthYear}년", onClick = {})
+            SettingMenuItem(
+                title = "${gender}ㆍ${birthYear}년",
+                onClick = onGenderBirthYearClick,
+            )
         }
     }
 }
@@ -118,6 +122,9 @@ private fun UserInfoCategoryDivider() {
 @Composable
 private fun UserInfoScreenPreview() {
     FeelinTheme {
-        UserInfoScreen(onBackClick = {})
+        UserInfoScreen(
+            onBackClick = {},
+            onGenderBirthYearClick = {},
+        )
     }
 }

--- a/app/src/main/java/com/lyrics/feelin/presentation/view/onboarding/genderage/OnboardingGenderAgeScreen.kt
+++ b/app/src/main/java/com/lyrics/feelin/presentation/view/onboarding/genderage/OnboardingGenderAgeScreen.kt
@@ -110,7 +110,7 @@ fun OnboardingGenderAgeScreen(
                         onClick = { selectedGender = "male" },
                         modifier = Modifier.weight(1f)
                     )
-                    Spacer(modifier = Modifier.width(12.dp))
+                    Spacer(modifier = Modifier.width(14.dp))
                     FeelinGenderButton(
                         text = "여성",
                         iconRes = if (selectedGender == "female") {
@@ -159,7 +159,7 @@ fun OnboardingGenderAgeScreen(
                         containerColor = feelinColors.systemActivate,
                         disabledContainerColor = feelinColors.systemDisable
                     ),
-                    shape = RoundedCornerShape(12.dp)
+                    shape = RoundedCornerShape(8.dp)
                 ) {
                     Text(
                         text = "다음",
@@ -282,7 +282,7 @@ private fun OnboardingGenderAgeScreenWithState(
                         onClick = { },
                         modifier = Modifier.weight(1f)
                     )
-                    Spacer(modifier = Modifier.width(12.dp))
+                    Spacer(modifier = Modifier.width(14.dp))
                     FeelinGenderButton(
                         text = "여성",
                         iconRes = if (selectedGender == "female") {
@@ -325,7 +325,7 @@ private fun OnboardingGenderAgeScreenWithState(
                         containerColor = feelinColors.systemActivate,
                         disabledContainerColor = feelinColors.systemDisable
                     ),
-                    shape = RoundedCornerShape(12.dp)
+                    shape = RoundedCornerShape(8.dp)
                 ) {
                     Text(
                         text = "다음",

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <style name="Theme.Feelin" parent="android:Theme.Material.NoActionBar" />
+</resources>

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <style name="Theme.Feelin" parent="android:Theme.Material.NoActionBar" />
+    <style name="Theme.Feelin" parent="Theme.Feelin.Dark" />
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,7 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <style name="Theme.Feelin" parent="android:Theme.Material.Light.NoActionBar" />
+    <!-- 시스템 나이트 모드와 무관하게 항상 라이트/다크로 resolve되는 명시적 스타일입니다.
+         온보딩처럼 라이트를 강제하는 화면의 네이티브 뷰(NumberPicker 등)에서 사용합니다. -->
+    <style name="Theme.Feelin.Light" parent="android:Theme.Material.Light.NoActionBar" />
+    <style name="Theme.Feelin.Dark" parent="android:Theme.Material.NoActionBar" />
+
+    <!-- 시스템 나이트 모드를 따라가는 앱 기본 테마입니다. values-night에서는 Theme.Feelin.Dark를 가리킵니다. -->
+    <style name="Theme.Feelin" parent="Theme.Feelin.Light" />
 
     <style name="Theme.Feelin.Starting" parent="Theme.SplashScreen">
         <item name="windowSplashScreenBackground">@color/brand_primary</item>

--- a/app/src/test/java/com/lyrics/feelin/navigation/FeelinDestinationTest.kt
+++ b/app/src/test/java/com/lyrics/feelin/navigation/FeelinDestinationTest.kt
@@ -1,0 +1,14 @@
+package com.lyrics.feelin.navigation
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class FeelinDestinationTest {
+    @Test
+    fun editGenderBirthYearUsesDedicatedRoute() {
+        assertEquals(
+            "edit_gender_birth_year",
+            FeelinDestination.EditGenderBirthYear.route,
+        )
+    }
+}


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features) - AI Agent generated
<!-- - [ ] Docs have been added / updated (for bug fixes / features) -->

## What kind of change does this PR introduce?
- Implement design

# What is the current behavior?
- 마이페이지 사용자 정보 화면에서 성별 및 출생연도를 수정할 수 있는 화면이 없었습니다. '성별 및 출생 년도' 항목을 탭해도 아무 동작도 하지 않았습니다.
- 다크모드에서 출생연도 피커(네이티브 NumberPicker)의 숫자가 보이지 않는 문제가 있었습니다. 앱 네이티브 테마(values/themes.xml)에 라이트 변형만 정의되어 있던 것이 근본 원인입니다.

# What is the new behavior (if this is a feature change)?
- 성별 및 출생연도 수정 화면(EditGenderBirthYearScreen)을 추가했습니다. 변경사항이 있을 때 뒤로가기 시 FeelinModalDialog로 이탈 여부를 확인하고, 저장 버튼은 변경사항이 있을 때만 활성화됩니다.
  - 현재는 더미 상태 기반이며, 실제 사용자 데이터 로드/저장 API 연동은 후속 작업입니다.
- FeelinDestination.EditGenderBirthYear를 추가하고, UserInfoScreen의 '성별 및 출생 년도' 항목 탭 시 해당 화면으로 이동하도록 네비게이션을 연결했습니다.
- 출생연도 피커의 다크모드를 대응했습니다.
  - values-night/themes.xml에 Theme.Feelin 다크 변형을 추가하고, 네이티브 테마를 Theme.Feelin.Light / Theme.Feelin.Dark 명시적 스타일로 분리한 뒤, 피커가 LocalDarkTheme에 맞는 명시적 테마를 NumberPicker에 적용합니다.
  - 온보딩(라이트 강제)에서는 라이트 피커가 유지됩니다. 회귀 방지 테스트(BirthYearPickerDarkThemeTest)를 포함합니다.
- Figma 스펙과의 정합성을 맞췄습니다.
  - FeelinGenderButton 높이 204dp 고정, corner radius 12→8
  - FeelinBirthYearPicker 높이 56→52
  - 온보딩 성별 버튼 간격 12→14dp.

## Does this PR introduce a breaking change?
없습니다.

## ScreenShots (If needed)

### Light mode
<p>
  <img width="200" alt="Screenshot_20260722_231059_ DEV  Feelin" src="https://github.com/user-attachments/assets/54e4b225-fb50-43cc-9dc4-b795c983590d" />
  <img width="200" alt="Screenshot_20260722_231103_ DEV  Feelin" src="https://github.com/user-attachments/assets/17268a86-6fe6-48f3-9d79-688a70b1cff8" />
  <img width="200" alt="Screenshot_20260722_231110_ DEV  Feelin" src="https://github.com/user-attachments/assets/25104238-54ff-4c9d-8dab-e73d095517a0" />
  <img width="200" alt="Screenshot_20260722_235944_ DEV  Feelin" src="https://github.com/user-attachments/assets/d0941b9b-7ad3-487d-9dd7-c98c40c6911c" />
</p>

### Dark mode
<p>
  <img width="200" alt="Screenshot_20260722_231035_ DEV  Feelin" src="https://github.com/user-attachments/assets/b4c592e2-a8da-4d48-a275-960df8973f4a" />
  <img width="200" alt="Screenshot_20260722_231042_ DEV  Feelin" src="https://github.com/user-attachments/assets/3e64b8e5-9ac8-48d2-b06e-e026d07088f5" />
  <img width="200" alt="Screenshot_20260722_231049_ DEV  Feelin" src="https://github.com/user-attachments/assets/f7f047e5-7522-438a-a3e8-23f36731054c" />
  <img width="200" alt="Screenshot_20260722_235953_ DEV  Feelin" src="https://github.com/user-attachments/assets/ac6b95c1-f52e-4788-acb6-213b2196e07d" />
</p>

## Other information:

### AI Agent (Kimi K3)
- `./gradlew detekt`, `:app:assembleDebug` 통과, 실기기 connected test 7/7 통과, 다크모드 실기기 동작 확인 완료
- 관련 이슈 #44: 이번 변경으로 앱 네이티브 테마의 다크 대응(#44의 전제조건)은 해결됐지만, WebView 컨텐츠 자체의 다크 처리는 포함하지 않습니다. 해당 이슈는 닫지 않습니다.

### User
> 별 의미는 없는 내용입니다.

Kimi가 한국어를 여전히 잘 못하네요. 수동으로 PR 본문의 오탈자를 수정했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added an “Edit gender & birth year” screen from My Page, including save and discard confirmation flows.
  * Added navigation to and from the new edit screen.

* **UI Improvements**
  * Improved the birth-year picker’s year formatting/selection and updated its dark/light rendering.
  * Refreshed gender and onboarding button sizing/rounded corners, plus minor trigger/button styling tweaks.

* **Theme Updates**
  * Added explicit Light/Dark theme variants to improve night-mode consistency.

* **Tests**
  * Added UI tests for the edit flow, picker sizing, navigation behavior, and theme-based color rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->